### PR TITLE
Fix the problem of failure to create wallet by importing private key

### DIFF
--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -542,7 +542,7 @@ class Abstract_Wallet(AddressSynchronizer, ABC):
         index = self.get_address_index(address)
         pk, compressed = self.keystore.get_private_key(index, password)
         txin_type = self.get_txin_type(address)
-        serialized_privkey = bitcoin.serialize_privkey(pk, compressed, txin_type, internal_use=True)
+        serialized_privkey = bitcoin.serialize_privkey(pk, compressed, txin_type, internal_use=False)
         return serialized_privkey
 
     def export_private_key_for_path(self, path: Union[Sequence[int], str], password: Optional[str]) -> str:

--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -1752,7 +1752,9 @@ class AndroidCommands(commands.Commands):
                 # status, msg = True, tx.txid()
         #          self.callbackIntent.onCallback(Status.broadcast, msg)
         else:
-            raise BaseException(_(('Cannot broadcast transaction Not connected')))
+            self.txdb.add_tx_time_info(tx.txid())
+            raise BaseException(_('Cannot broadcast transaction Not connected'))
+
 
     def set_use_change(self, status_change):
         '''
@@ -2354,6 +2356,8 @@ class AndroidCommands(commands.Commands):
         try:
             address = self.wallet.get_addresses()[0]
             priv = self.wallet.export_private_key(address, password=password)
+            if -1 != priv.find(":"):
+                priv = priv.split(":")[1]
             return priv
         except BaseException as e:
             raise e


### PR DESCRIPTION


## What does this implement/fix? Explain your changes.
1.Fix the problem of failure to create wallet by importing private key
2.No time information saved for transaction sending failure after disconnection

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
https://github.com/OneKeyHQ/TaskHub/issues/538

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
App for Android

## Any other comments?
No