### PR TITLE
iOS: fix Clear the passcode field when input finished

### DIFF
--- a/ios/CustomCode/Modules/PassWord/Validation/OKValidationPwdController.m
+++ b/ios/CustomCode/Modules/PassWord/Validation/OKValidationPwdController.m
@@ -94,6 +94,7 @@ typedef enum {
         configure.rectBackgroundColor = HexColor(0xF2F2F2);
         configure.backgroundColor = [UIColor whiteColor];
         configure.threePartyKeyboard = NO;
+        configure.clearTextFieldWhenFinish = YES;
     }];
 }
 

--- a/ios/CustomCode/Modules/PassWord/View/CLPasswordInputView.h
+++ b/ios/CustomCode/Modules/PassWord/View/CLPasswordInputView.h
@@ -53,6 +53,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) UIColor *backgroundColor;
 /**是否允许三方键盘，默认NO*/
 @property (nonatomic, assign) BOOL threePartyKeyboard;
+/**完成输入密码后清空密码 TextField*/
+@property (nonatomic, assign) BOOL clearTextFieldWhenFinish;
 
 @end
 

--- a/ios/CustomCode/Modules/PassWord/View/CLPasswordInputView.m
+++ b/ios/CustomCode/Modules/PassWord/View/CLPasswordInputView.m
@@ -113,6 +113,7 @@
             if (self.text.length == self.configure.passwordNum) {
                 if ([self.delegate respondsToSelector:@selector(passwordInputViewCompleteInput:)]) {
                     [self.delegate passwordInputViewCompleteInput:self];
+                    [self clearTextField];
                 }
             }
             [self setNeedsDisplay];
@@ -130,6 +131,16 @@
         [self.delegate passwordInputViewDidDeleteBackward:self];
     }
     [self setNeedsDisplay];
+}
+
+- (void)clearTextField {
+    if (!self.configure.clearTextFieldWhenFinish || !self.text.length) {
+        return;
+    }
+    [self.text setString:@""];
+    if ([self.delegate respondsToSelector:@selector(passwordInputViewDidChange:)]) {
+        [self.delegate passwordInputViewDidChange:self];
+    }
 }
 
 -(void)layoutSubviews {


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
fix 对于需要身份校验的敏感流程，校验通过后若用户再次返回到校验主密码页，输入框应该清空 #467
Clear the passcode field when input finished

## Does this close any currently open issues?  
https://github.com/OneKeyHQ/TaskHub/issues/467

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
iPhone xs max iOS 14.2

## Any other comments?
…
