### PR TITLE
iOS: fix Clear the long passcode field after submit

### DIFF
--- a/ios/CustomCode/Modules/PassWord/Validation/OKValidationPwdController.m
+++ b/ios/CustomCode/Modules/PassWord/Validation/OKValidationPwdController.m
@@ -179,9 +179,12 @@ typedef enum {
     }
     if ([self.longPwdFirstTextField.text containsChinese]) {
         [kTools tipMessage:MyLocalizedString(@"The password cannot contain Chinese", nil)];
+        self.longPwdFirstTextField.text = @"";
         return;
     }
     [self validationPwd:self.longPwdFirstTextField.text];
+    self.longPwdFirstTextField.text = @"";
+
 }
 
 - (void)validationPwd:(NSString *)pwd


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Clear the long passcode field after submit.
修复前：长短密码输入错误，弹出提示，密码框中仍是错误密码 ；需手动删除重新填写
修复后：长短密码输入错误，弹出提示，且密码框清空

## Does this close any currently open issues?  
https://github.com/OneKeyHQ/TaskHub/issues/575

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
…

## Any other comments?
…
