### PR TITLE
Optimize the password check page and fix toast show OneKey

### DIFF
--- a/android/app/src/main/java/org/haobtc/onekey/activities/base/MyApplication.java
+++ b/android/app/src/main/java/org/haobtc/onekey/activities/base/MyApplication.java
@@ -131,10 +131,16 @@ public class MyApplication extends Application implements ViewModelStoreOwner {
         } else {
             info = e.toString();
         }
-        if(TextUtils.isEmpty(info)){
+        if (TextUtils.isEmpty(info)) {
             return;
         }
-        S_HANDLER.post(() -> Toast.makeText(MyApplication.this,info,Toast.LENGTH_SHORT).show());
+        S_HANDLER.post(() ->
+                {
+                    Toast toast = Toast.makeText(MyApplication.this, null, Toast.LENGTH_SHORT);
+                    toast.setText(info);
+                    toast.show();
+                }
+        );
     }
 
     @NonNull

--- a/android/app/src/main/java/org/haobtc/onekey/onekeys/homepage/process/ReceiveHDActivity.java
+++ b/android/app/src/main/java/org/haobtc/onekey/onekeys/homepage/process/ReceiveHDActivity.java
@@ -291,7 +291,7 @@ public class ReceiveHDActivity extends BaseActivity implements BusinessAsyncTask
     @Override
     public void onException(Exception e) {
         EventBus.getDefault().post(new ExitEvent());
-        MyApplication.getInstance().toastErr(e);
+        showToast(e.getMessage());
     }
 
     @Override

--- a/android/app/src/main/java/org/haobtc/onekey/ui/base/IBaseView.java
+++ b/android/app/src/main/java/org/haobtc/onekey/ui/base/IBaseView.java
@@ -1,5 +1,4 @@
 package org.haobtc.onekey.ui.base;
-
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -10,13 +9,11 @@ import android.text.TextUtils;
 import android.util.DisplayMetrics;
 import android.view.MotionEvent;
 import android.view.View;
-import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.Toast;
 
 import androidx.annotation.RequiresApi;
-import androidx.appcompat.app.AppCompatActivity;
 
 public interface IBaseView {
 
@@ -152,8 +149,11 @@ public interface IBaseView {
         if (id == 0) {
             return;
         }
-        runOnUiThread(() -> Toast.makeText(getActivity(), getActivity().getString(id), Toast.LENGTH_SHORT).show());
-
+        runOnUiThread(() -> {
+            Toast toast = Toast.makeText(getActivity(), null, Toast.LENGTH_SHORT);
+            toast.setText(getActivity().getString(id));
+            toast.show();
+        });
     }
     /**
      * toast
@@ -164,8 +164,13 @@ public interface IBaseView {
         if (TextUtils.isEmpty(info)) {
             return;
         }
-        runOnUiThread(() -> Toast.makeText(getActivity(), info, Toast.LENGTH_SHORT).show());
-
+        runOnUiThread(() ->
+                {
+                    Toast toast = Toast.makeText(getActivity(), null, Toast.LENGTH_SHORT);
+                    toast.setText(info);
+                    toast.show();
+                }
+        );
     }
 
 

--- a/android/app/src/main/java/org/haobtc/onekey/viewmodel/PassWordViewModel.java
+++ b/android/app/src/main/java/org/haobtc/onekey/viewmodel/PassWordViewModel.java
@@ -1,0 +1,59 @@
+package org.haobtc.onekey.viewmodel;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+
+import org.haobtc.onekey.activities.base.MyApplication;
+import org.haobtc.onekey.bean.LocalWalletInfo;
+import org.haobtc.onekey.business.wallet.SystemConfigManager;
+import org.haobtc.onekey.constant.Constant;
+import org.haobtc.onekey.manager.PreferencesManager;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @Description: 身份校验页面的ViewModel
+ * @Author: peter Qin
+ */
+public class PassWordViewModel extends ViewModel {
+    public MutableLiveData<Integer> passSetType = new MutableLiveData<>();
+    public MutableLiveData<Boolean> isLongType = new MutableLiveData<>();
+    public SystemConfigManager systemConfigManager = new SystemConfigManager(MyApplication.getInstance());
+
+    public PassWordViewModel () {
+        checkPssLengthType();
+    }
+
+    private void checkPssLengthType () {
+        String type = systemConfigManager.getPassWordType();
+        if (Constant.SOFT_HD_PASS_TYPE_LONG.equals(type)) {
+            isLongType.postValue(true);
+        } else {
+            isLongType.postValue(false);
+        }
+    }
+
+    public void checkIsSetType (int numType) {
+        passSetType.postValue(numType);
+        List<String> needPassWallets = new ArrayList<>();
+        Map<String, ?> jsonToMap = PreferencesManager.getAll(MyApplication.getInstance(), Constant.WALLETS);
+        jsonToMap.entrySet().forEach(stringEntry -> {
+            LocalWalletInfo info = LocalWalletInfo.objectFromData(stringEntry.getValue().toString());
+            String type = info.getType();
+            String label = info.getLabel();
+            if (!type.contains("hw") && !"btc-watch-standard".equals(type)) {
+                needPassWallets.add(label);
+            }
+        });
+        if (needPassWallets.size() == 0) {
+            passSetType.postValue(0);
+        }
+    }
+
+    public void setPassLengthType (boolean isLong) {
+        systemConfigManager.setPassWordType(isLong ? SystemConfigManager.SoftHdPassType.LONG : SystemConfigManager.SoftHdPassType.SHORT);
+        isLongType.postValue(isLong);
+    }
+
+}

--- a/android/app/src/main/res/layout/dialog_warning.xml
+++ b/android/app/src/main/res/layout/dialog_warning.xml
@@ -63,7 +63,6 @@
                 android:layout_marginTop="20dp"
                 android:textColor="@color/button_bk"
                 android:textSize="@dimen/text_size"
-                android:text="@string/security_risks"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/imageView9" />

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -103,7 +103,7 @@
     <string name="copy_self">复制</string>
     <string name="address_qr">地址二维码</string>
     <string name="attention">注意：该地址仅支持BTC收款，转入其他币种将无法找回</string>
-    <string name="prompt_message">请在币信Key硬件上确认以下信息后，点击”OK”按钮</string>
+    <string name="prompt_message">请在OneKey硬件上确认以下信息后，点击”OK”按钮</string>
     <string name="picture">this is a picture</string>
     <string name="wallet_create_successful">钱包创建成功</string>
     <string name="balance">账户余额</string>
@@ -494,7 +494,6 @@
     <string name="please_change_xpub">此xpub已存在，请更换</string>
     <string name="error_wallet_transaction">此交易与当前钱包无关</string>
     <string name="key_wrong_prompte">读取过程中，请保持手机与OneKey贴合</string>
-    <string name="security_risks">BinKEY存在安全风险</string>
     <string name="official_firmware_suggest">检测到未使用官方固件，请更换官方固件</string>
     <string name="pin_confirm_hardware">请在硬件上确认PIN码</string>
     <string name="communicating">与OneKey通讯中</string>
@@ -522,7 +521,7 @@
     <string name="verifying_pin">正在验证PIN码</string>
     <string name="reading_signature">签名读取中</string>
     <string name="transaction_parse_error">交易解析失败</string>
-    <string name="testnet">币信Key T</string>
+    <string name="testnet">OneKey T</string>
     <string name="regnet">OneKey</string>
     <string name="update_file_not_exist">升级文件不存在</string>
     <string name="tip_connnection">数据传输需要一些时间，请保持连接状态</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -67,7 +67,7 @@
     <string name="update_file_format_error">Upgrade file should end with. zip or .bin</string>
     <string name="addspeed_success">Acceleration completed!</string>
     <string name="key_wrong_prompte">Please keep your phone close to the OneKey during the reading process</string>
-    <string name="security_risks">Security risks exist in BinKEY</string>
+
     <string name="communicating">Communicating with OneKey</string>
     <string name="tip_closer">Data transmissing. Please keep OneKey close to the phone</string>
     <string name="waitting_touch">Pending for OneKey</string>


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
身份校验页面添加viewModel，修复部分机型Toast 弹框会携带OneKey
## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
no issue
## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): 

## Where has this been tested?
…

## Any other comments?
…
