### PR TITLE
Fixed S132_ Bluetooth upgrade and Change the default PIN to confirm o…

### DIFF
--- a/android/app/src/main/java/org/haobtc/onekey/activities/settings/HardwareDetailsActivity.java
+++ b/android/app/src/main/java/org/haobtc/onekey/activities/settings/HardwareDetailsActivity.java
@@ -59,7 +59,6 @@ import org.haobtc.onekey.ui.activity.VerifyPinActivity;
 import org.haobtc.onekey.ui.base.BaseActivity;
 import org.haobtc.onekey.ui.dialog.DeleteLocalDeviceDialog;
 import org.haobtc.onekey.ui.dialog.InvalidDeviceIdWarningDialog;
-import org.haobtc.onekey.ui.dialog.UnBackupTipDialog;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -258,7 +257,7 @@ public class HardwareDetailsActivity extends BaseActivity implements BusinessAsy
             bundle.putString(Constant.TAG_FIRMWARE_VERSION_NEW, versionStm32);
             bundle.putString(Constant.TAG_FIRMWARE_UPDATE_DES, descriptionStm32);
         }
-        boolean showNrf = isBootloader || !Strings.isNullOrEmpty(nrfVersion) && !Strings.isNullOrEmpty(versionNrf) && versionNrf.compareTo(nrfVersion) > 0;
+        boolean showNrf = getShowNrf(isBootloader, versionNrf);
         if (showNrf) {
             bundle.putString(Constant.TAG_NRF_DOWNLOAD_URL, urlPrefix + urlNrf);
             bundle.putString(Constant.TAG_NRF_VERSION_NEW, versionNrf);
@@ -271,6 +270,24 @@ public class HardwareDetailsActivity extends BaseActivity implements BusinessAsy
         bundle.putString(Constant.TAG_LABEL, label);
         bundle.putString(Constant.DEVICE_ID, deviceId);
         return bundle;
+    }
+
+    /**
+     * @param isBootloader 如果是 Bootloader 模式就直接显示升级，否则去校验版本升级
+     * @param versionNrf
+     *
+     * @return
+     */
+    private boolean getShowNrf(boolean isBootloader, String versionNrf) {
+        if (isBootloader) {
+            return true;
+        } else {
+            if (!Strings.isNullOrEmpty(nrfVersion) && !Strings.isNullOrEmpty(versionNrf)) {
+                return versionNrf.compareTo(nrfVersion) > 0 || Objects.equals(nrfVersion, Constant.BLE_OLDEST_VER);
+            } else {
+                return false;
+            }
+        }
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)

--- a/android/app/src/main/java/org/haobtc/onekey/constant/Constant.java
+++ b/android/app/src/main/java/org/haobtc/onekey/constant/Constant.java
@@ -381,7 +381,11 @@ public final class Constant {
     public static final String WALLET_NAME = "walletName";
     public static final String FINISH = "finish";
     public static final String BTC_WATCH = "btc-watch-standard";
-    public static final String CUSTOM_FEERATE="custom_feerate";
-    public static final String HDWALLET_NAME="hdWalletName";
+    public static final String CUSTOM_FEERATE = "custom_feerate";
+    public static final String HDWALLET_NAME = "hdWalletName";
+    /**
+     * 蓝牙最早版本号
+     */
+    public static final String BLE_OLDEST_VER = "s132_";
 
 }

--- a/android/app/src/main/java/org/haobtc/onekey/manager/HardwareCallbackHandler.java
+++ b/android/app/src/main/java/org/haobtc/onekey/manager/HardwareCallbackHandler.java
@@ -62,7 +62,7 @@ public class HardwareCallbackHandler extends Handler {
         switch (msg.what) {
             case PIN_CURRENT:
             case PIN_NEW_FIRST:
-                boolean isVerifyPinOnHardware = (boolean)PreferencesManager.get(fragmentActivity, "Preferences", Constant.PIN_VERIFY_ON_HARDWARE, false);
+                boolean isVerifyPinOnHardware = (boolean) PreferencesManager.get(fragmentActivity, "Preferences", Constant.PIN_VERIFY_ON_HARDWARE, true);
                 if (isVerifyPinOnHardware) {
                    fragmentActivity.startActivity(new Intent(fragmentActivity, InputPinOnHardware.class));
                    PyEnv.setPin(Constant.PIN_INVALID);

--- a/android/app/src/main/java/org/haobtc/onekey/ui/activity/PinVerifyWaySelector.java
+++ b/android/app/src/main/java/org/haobtc/onekey/ui/activity/PinVerifyWaySelector.java
@@ -35,7 +35,7 @@ public class PinVerifyWaySelector extends BaseActivity {
      */
     @Override
     public void init() {
-        boolean isVerifyOnHardware = (boolean)PreferencesManager.get(this, "Preferences", Constant.PIN_VERIFY_ON_HARDWARE, false);
+        boolean isVerifyOnHardware = (boolean)PreferencesManager.get(this, "Preferences", Constant.PIN_VERIFY_ON_HARDWARE, true);
         if (isVerifyOnHardware) {
             onHardware.setChecked(true);
             onApp.setChecked(false);

--- a/android/app/src/main/java/org/haobtc/onekey/ui/activity/SearchDevicesActivity.java
+++ b/android/app/src/main/java/org/haobtc/onekey/ui/activity/SearchDevicesActivity.java
@@ -443,14 +443,34 @@ public class SearchDevicesActivity extends BaseActivity implements BleDeviceAdap
         bundle.putString(Constant.TAG_FIRMWARE_VERSION_NEW, versionStm32);
         bundle.putString(Constant.TAG_FIRMWARE_UPDATE_DES, descriptionStm32);
         // todo: 此处的判定条件在版本号出现2位数以上时会有问题
-        boolean showNrf = isBootloader || !Strings.isNullOrEmpty(curNrfVersion) && !Strings.isNullOrEmpty(versionNrf) && versionNrf.compareTo(curNrfVersion) > 0;
-        if (showNrf) {
+//        boolean showNrf = isBootloader || !Strings.isNullOrEmpty(curNrfVersion) && !Strings.isNullOrEmpty(versionNrf) && (versionNrf.compareTo(curNrfVersion) > 0 || Objects.equal(curNrfVersion, Constant.BLE_OLDEST_VER));
+        boolean show = getShowNrf(isBootloader, curNrfVersion, versionNrf);
+        if (show) {
             bundle.putString(Constant.TAG_NRF_DOWNLOAD_URL, urlPrefix + urlNrf);
             bundle.putString(Constant.TAG_NRF_VERSION_NEW, versionNrf);
             bundle.putString(Constant.TAG_NRF_UPDATE_DES, descriptionNrf);
         }
         return bundle;
     }
+
+    /**
+     * @param isBootloader 如果是 Bootloader 模式就直接显示升级，否则去校验版本
+     * @param versionNrf
+     *
+     * @return
+     */
+    private boolean getShowNrf(boolean isBootloader, String curNrfVersion, String versionNrf) {
+        if (isBootloader) {
+            return true;
+        } else {
+            if (!Strings.isNullOrEmpty(curNrfVersion) && !Strings.isNullOrEmpty(versionNrf)) {
+                return versionNrf.compareTo(curNrfVersion) > 0 || java.util.Objects.equals(curNrfVersion, Constant.BLE_OLDEST_VER);
+            } else {
+                return false;
+            }
+        }
+    }
+
 
     /**
      * 初始化蓝牙前检查权限，为后续在 BleManager 抽离 Activity 作准备，BleManager 持有 Activity 此处会发生内存泄漏。

--- a/android/app/src/main/res/layout/transaction_setting.xml
+++ b/android/app/src/main/res/layout/transaction_setting.xml
@@ -73,7 +73,8 @@
             android:background="@color/button_bk_ddake"
             android:orientation="horizontal"
             android:paddingStart="@dimen/dp_20"
-            android:paddingEnd="@dimen/dp_20">
+            android:paddingEnd="@dimen/dp_20"
+            android:visibility="gone">
 
             <TextView
                 android:layout_width="0dp"
@@ -195,7 +196,5 @@
                 android:track="@drawable/switch_custom_track_selector"
                 tools:ignore="UseSwitchCompatOrMaterialXml" />
         </LinearLayout>
-
     </LinearLayout>
-
 </LinearLayout>


### PR DESCRIPTION
…n the hardware

## What does this implement/fix? Explain your changes.
修复《客服反馈》新安装 App，配对 HW，默认 PIN 不在 HW 上输入，而是在 App。
修复《客服反馈》蓝牙版本s132_不能升级蓝牙
隐藏交易设置里面的 使用RBF 入口

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
OneKeyHQ/TaskHub#661,OneKeyHQ/TaskHub#660
## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
…

## Any other comments?
…
