### PR TITLE
The eth wallet created with the private key and keystore generates the checksum address

### DIFF
--- a/electrum/eth_wallet.py
+++ b/electrum/eth_wallet.py
@@ -823,7 +823,7 @@ class Imported_Eth_Wallet(Simple_Eth_Wallet):
             except BaseException as e:
                 bad_keys.append((key, _('invalid private key') + f': {e}'))
                 continue
-            addr = pubkey.to_address()
+            addr = PyWalib.web3.toChecksumAddress(pubkey.to_address())
             good_addr.append(addr)
             self.db.add_imported_address(addr, {'pubkey':pubkey.__str__()})
             #self.add_address(addr)
@@ -1153,5 +1153,3 @@ class Eth_Wallet(object):
         if wallet_type in wallet_constructors:
             return wallet_constructors[wallet_type]
         raise WalletFileException("Unknown wallet type: " + str(wallet_type))
-
-


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
The eth wallet created with the private key and keystore generates the checksum address

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
https://github.com/OneKeyHQ/TaskHub/issues/733

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
python

## Any other comments?
…
