### PR TITLE
Android:Wallet occasional wallet list page type flag is not displayed

### DIFF
--- a/android/app/src/main/java/org/haobtc/onekey/adapter/WalletListTypeAdapter.java
+++ b/android/app/src/main/java/org/haobtc/onekey/adapter/WalletListTypeAdapter.java
@@ -65,6 +65,7 @@ public class WalletListTypeAdapter extends BaseMultiItemQuickAdapter<WalletInfo,
                     helper.getView(R.id.text_type).setVisibility(View.VISIBLE);
                     helper.setText(R.id.text_type, "HD");
                 } else if (item.type.contains("hw")) {
+                    helper.getView(R.id.text_type).setVisibility(View.VISIBLE);
                     String type = item.type.substring(item.type.indexOf("hw-") + 3);
                     helper.setText(R.id.text_type, mContext.getString(R.string.hardwares));
                 } else if (item.type.contains("watch")) {


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
+ 偶现的钱包列表页硬件钱包的硬件的类型 logo 不展示。

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
None

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
…

## Any other comments?
…
