### PR TITLE
Successful hardware upgrades show older versions

### DIFF
--- a/android/app/src/main/java/org/haobtc/onekey/activities/settings/OneKeyManageActivity.java
+++ b/android/app/src/main/java/org/haobtc/onekey/activities/settings/OneKeyManageActivity.java
@@ -4,13 +4,17 @@ import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.view.View;
 import android.widget.ImageView;
-
 import androidx.recyclerview.widget.RecyclerView;
-
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import butterknife.OnClick;
 import com.chad.library.adapter.base.BaseQuickAdapter;
 import com.google.common.base.Strings;
 import com.google.gson.Gson;
-
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -20,27 +24,18 @@ import org.haobtc.onekey.adapter.BixinkeyManagerAdapter;
 import org.haobtc.onekey.aop.SingleClick;
 import org.haobtc.onekey.bean.HardwareFeatures;
 import org.haobtc.onekey.constant.Constant;
-import org.haobtc.onekey.manager.PreferencesManager;
 import org.haobtc.onekey.event.FixBixinkeyNameEvent;
+import org.haobtc.onekey.manager.PreferencesManager;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import butterknife.BindView;
-import butterknife.ButterKnife;
-import butterknife.OnClick;
-
-/**
- * @author liyan
- */
+/** @author liyan */
 public class OneKeyManageActivity extends BaseActivity {
 
     @BindView(R.id.img_back)
     ImageView imgBack;
+
     @BindView(R.id.recl_bixinKey_list)
     RecyclerView reclBixinKeyList;
+
     private List<HardwareFeatures> deviceValue;
 
     @Override
@@ -56,9 +51,7 @@ public class OneKeyManageActivity extends BaseActivity {
     }
 
     @Override
-    public void initData() {
-
-    }
+    public void initData() {}
 
     @Override
     protected void onResume() {
@@ -68,37 +61,68 @@ public class OneKeyManageActivity extends BaseActivity {
 
     private void getKeyList() {
         deviceValue = new ArrayList<>();
-        Map<String, ?> devicesAll = PreferencesManager.getAll(this, Constant.DEVICES);;
-        //key
+        Map<String, ?> devicesAll = PreferencesManager.getAll(this, Constant.DEVICES);
+        ;
+        // key
         for (Map.Entry<String, ?> entry : devicesAll.entrySet()) {
             String mapValue = (String) entry.getValue();
-            HardwareFeatures hardwareFeatures = new Gson().fromJson(mapValue, HardwareFeatures.class);
+            HardwareFeatures hardwareFeatures =
+                    new Gson().fromJson(mapValue, HardwareFeatures.class);
             deviceValue.add(hardwareFeatures);
         }
         if (deviceValue != null) {
             BixinkeyManagerAdapter bixinkeyManagerAdapter = new BixinkeyManagerAdapter(deviceValue);
             reclBixinKeyList.setAdapter(bixinkeyManagerAdapter);
-            bixinkeyManagerAdapter.setOnItemChildClickListener(new BaseQuickAdapter.OnItemChildClickListener() {
-                @SingleClick
-                @Override
-                public void onItemChildClick(BaseQuickAdapter adapter, View view, int position) {
-                    if (view.getId() == R.id.relativeLayout_bixinkey) {
-                        String firmwareVersion = Optional.ofNullable(deviceValue.get(position).getOneKeyVersion()).orElse(deviceValue.get(position).getMajorVersion() + "." + deviceValue.get(position).getMinorVersion() + "." + deviceValue.get(position).getPatchVersion());
-                        String nrfVersion = deviceValue.get(position).getBleVer();
-                        String label = Strings.isNullOrEmpty(deviceValue.get(position).getLabel()) ?
-                                deviceValue.get(position).getBleName() : deviceValue.get(position).getLabel();
-                        Intent intent = new Intent(OneKeyManageActivity.this, HardwareDetailsActivity.class);
-                        intent.putExtra(Constant.TAG_LABEL, label);
-                        intent.putExtra(Constant.TAG_BLE_NAME, deviceValue.get(position).getBleName());
-                        intent.putExtra(Constant.TAG_FIRMWARE_VERSION, firmwareVersion);
-                        intent.putExtra(Constant.TAG_NRF_VERSION, nrfVersion);
-                        intent.putExtra(Constant.DEVICE_ID, deviceValue.get(position).getDeviceId());
-                        intent.putExtra(Constant.TAG_HARDWARE_VERIFY, deviceValue.get(position).isVerify());
-                        intent.putExtra(Constant.TAG_IS_BACKUP_ONLY, deviceValue.get(position).isBackupOnly());
-                        startActivity(intent);
-                    }
-                }
-            });
+            bixinkeyManagerAdapter.setOnItemChildClickListener(
+                    new BaseQuickAdapter.OnItemChildClickListener() {
+                        @SingleClick
+                        @Override
+                        public void onItemChildClick(
+                                BaseQuickAdapter adapter, View view, int position) {
+                            if (view.getId() == R.id.relativeLayout_bixinkey) {
+                                String firmwareVersion =
+                                        Optional.ofNullable(
+                                                        deviceValue
+                                                                .get(position)
+                                                                .getOneKeyVersion())
+                                                .orElse(
+                                                        deviceValue.get(position).getMajorVersion()
+                                                                + "."
+                                                                + deviceValue
+                                                                        .get(position)
+                                                                        .getMinorVersion()
+                                                                + "."
+                                                                + deviceValue
+                                                                        .get(position)
+                                                                        .getPatchVersion());
+                                String nrfVersion = deviceValue.get(position).getBleVer();
+                                String label =
+                                        Strings.isNullOrEmpty(deviceValue.get(position).getLabel())
+                                                ? deviceValue.get(position).getBleName()
+                                                : deviceValue.get(position).getLabel();
+                                Intent intent =
+                                        new Intent(
+                                                OneKeyManageActivity.this,
+                                                HardwareDetailsActivity.class);
+                                intent.putExtra(Constant.TAG_LABEL, label);
+                                intent.putExtra(
+                                        Constant.TAG_BLE_NAME,
+                                        deviceValue.get(position).getBleName());
+                                intent.putExtra(Constant.TAG_FIRMWARE_VERSION, firmwareVersion);
+                                intent.putExtra(Constant.TAG_NRF_VERSION, nrfVersion);
+                                intent.putExtra(
+                                        Constant.DEVICE_ID,
+                                        deviceValue.get(position).getDeviceId());
+                                intent.putExtra(
+                                        Constant.TAG_HARDWARE_VERIFY,
+                                        deviceValue.get(position).isVerify());
+                                intent.putExtra(
+                                        Constant.TAG_IS_BACKUP_ONLY,
+                                        deviceValue.get(position).isBackupOnly());
+                                startActivity(intent);
+                            }
+                        }
+                    });
         }
     }
 
@@ -121,10 +145,3 @@ public class OneKeyManageActivity extends BaseActivity {
         EventBus.getDefault().unregister(this);
     }
 }
-
-
-
-
-
-
-

--- a/android/app/src/main/java/org/haobtc/onekey/ui/activity/HardwareUpgradeActivity.java
+++ b/android/app/src/main/java/org/haobtc/onekey/ui/activity/HardwareUpgradeActivity.java
@@ -66,10 +66,13 @@ public class HardwareUpgradeActivity extends BaseActivity {
 
     @BindView(R.id.img_back)
     ImageView imgBack;
-
+    // 当前固件版本
     public static String currentFirmwareVersion;
+    // 当前蓝牙版本
     public static String currentNrfVersion;
+    // 固件的新版本
     public static String newFirmwareVersion;
+    // 蓝牙的新版本
     public static String newNrfVersion;
     public static String firmwareChangelog;
     public static String nrfChangelog;
@@ -97,6 +100,7 @@ public class HardwareUpgradeActivity extends BaseActivity {
                     if (!Strings.isNullOrEmpty(features)) {
                         HardwareFeatures features1 = HardwareFeatures.objectFromData(features);
                         features1.setBleVer(newNrfVersion);
+                        currentNrfVersion = newNrfVersion;
                         newNrfVersion = null;
                         devices.edit().putString(deviceId, features1.toString()).apply();
                         if (hardwareUpgradeFragment != null && hardwareUpgradeFragment.isAdded()) {
@@ -203,10 +207,10 @@ public class HardwareUpgradeActivity extends BaseActivity {
     /** init */
     @Override
     public void init() {
+        devices = getSharedPreferences("devices", Context.MODE_PRIVATE);
         updateTitle(R.string.verson_update);
         dealBundle(Objects.requireNonNull(getIntent().getExtras()));
         hardwareUpgradeFragment = new HardwareUpgradeFragment();
-        devices = getSharedPreferences("devices", Context.MODE_PRIVATE);
         startFragment(hardwareUpgradeFragment);
     }
 
@@ -224,6 +228,14 @@ public class HardwareUpgradeActivity extends BaseActivity {
         deviceId = bundle.getString(Constant.DEVICE_ID);
         cacheDir = getExternalCacheDir().getPath();
         isForceUpdate = bundle.getBoolean(Constant.FORCE_UPDATE, false);
+        String features = devices.getString(deviceId, "");
+        if (!Strings.isNullOrEmpty(features)) {
+            HardwareFeatures hardware = HardwareFeatures.objectFromData(features);
+            if (hardware.getBleVer().equals(newNrfVersion)) {
+                currentNrfVersion = newNrfVersion;
+                newNrfVersion = null;
+            }
+        }
     }
 
     /**
@@ -367,6 +379,7 @@ public class HardwareUpgradeActivity extends BaseActivity {
         if (!Strings.isNullOrEmpty(features)) {
             HardwareFeatures features1 = HardwareFeatures.objectFromData(features);
             features1.setOneKeyVersion(newFirmwareVersion);
+            currentFirmwareVersion = newFirmwareVersion;
             newFirmwareVersion = "";
             devices.edit().putString(deviceId, features1.toString()).apply();
             if (hardwareUpgradeFragment != null && hardwareUpgradeFragment.isAdded()) {
@@ -485,6 +498,7 @@ public class HardwareUpgradeActivity extends BaseActivity {
     public void onExit(ExitEvent exitEvent) {
         if (hasWindowFocus()) {
             startFragment(hardwareUpgradeFragment);
+            hardwareUpgradeFragment.refreshView();
         }
     }
 }


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
硬件升级重启后，点击按钮「升级固件」，显示旧版本，没有更新成新版本
单独升级蓝牙，升级成功之后，页面再次打开也更新为新版本
## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
OneKeyHQ/TaskHub#695

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
…

## Any other comments?
…
