### PR TITLE
The bootLoader mode upgrade page is not refreshed

### DIFF
--- a/android/app/src/main/java/org/haobtc/onekey/ui/activity/HardwareUpgradeActivity.java
+++ b/android/app/src/main/java/org/haobtc/onekey/ui/activity/HardwareUpgradeActivity.java
@@ -100,12 +100,12 @@ public class HardwareUpgradeActivity extends BaseActivity {
                     if (!Strings.isNullOrEmpty(features)) {
                         HardwareFeatures features1 = HardwareFeatures.objectFromData(features);
                         features1.setBleVer(newNrfVersion);
-                        currentNrfVersion = newNrfVersion;
-                        newNrfVersion = null;
                         devices.edit().putString(deviceId, features1.toString()).apply();
-                        if (hardwareUpgradeFragment != null && hardwareUpgradeFragment.isAdded()) {
-                            hardwareUpgradeFragment.refreshView();
-                        }
+                    }
+                    currentNrfVersion = newNrfVersion;
+                    newNrfVersion = null;
+                    if (hardwareUpgradeFragment != null && hardwareUpgradeFragment.isAdded()) {
+                        hardwareUpgradeFragment.refreshView();
                     }
                 }
 
@@ -379,12 +379,12 @@ public class HardwareUpgradeActivity extends BaseActivity {
         if (!Strings.isNullOrEmpty(features)) {
             HardwareFeatures features1 = HardwareFeatures.objectFromData(features);
             features1.setOneKeyVersion(newFirmwareVersion);
-            currentFirmwareVersion = newFirmwareVersion;
-            newFirmwareVersion = "";
             devices.edit().putString(deviceId, features1.toString()).apply();
-            if (hardwareUpgradeFragment != null && hardwareUpgradeFragment.isAdded()) {
-                hardwareUpgradeFragment.refreshView();
-            }
+        }
+        currentFirmwareVersion = newFirmwareVersion;
+        newFirmwareVersion = "";
+        if (hardwareUpgradeFragment != null && hardwareUpgradeFragment.isAdded()) {
+            hardwareUpgradeFragment.refreshView();
         }
     }
     /** stm32固件升级失败回调 */


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
bootLoader 模式升级完成页面未刷新

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
OneKeyHQ/TaskHub#799

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
…

## Any other comments?
…
