### PR TITLE
Inaccurate error message when verifying keystore

### DIFF
--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -255,7 +255,6 @@ class AndroidCommands(commands.Commands):
         self.rbf_tx = ""
         self.m = 0
         self.n = 0
-        # self.sync_timer = None
         self.config.set_key("auto_connect", True, True)
         global ticker
         ticker = Ticker(5.0, self.ticker_action)
@@ -375,7 +374,7 @@ class AndroidCommands(commands.Commands):
             if x:
                 out["unmatured"] = self.format_amount(x, is_diff=True).strip()
 
-        if out:
+        if out and self.callbackIntent is not None:
             self.callbackIntent.onCallback("update_status=%s" % json.dumps(out, cls=DecimalEncoder))
 
     def get_remove_flag(self, tx_hash):
@@ -2950,8 +2949,11 @@ class AndroidCommands(commands.Commands):
             elif flag == "keystore":
                 try:
                     Account.decrypt(json.loads(data), password).hex()
-                except BaseException:
+                except (TypeError, KeyError, NotImplementedError):
                     raise BaseException(_("Incorrect eth keystore."))
+                except BaseException as e:
+                    raise InvalidPasswordException()
+
             elif flag == "public":
                 try:
                     uncom_key = get_uncompressed_key(data)


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
验证keystore时 提示信息不正确

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
https://github.com/OneKeyHQ/TaskHub/issues/800

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
Python

## Any other comments?
…
