### PR TITLE
Add sign_message and verify_message for eth and btc wallet

### DIFF
--- a/electrum/eth_wallet.py
+++ b/electrum/eth_wallet.py
@@ -89,7 +89,6 @@ class Abstract_Eth_Wallet(ABC):
     gap_limit_for_change = 1
 
 
-    txin_type: str
     wallet_type: str
 
     def __init__(self, db: WalletDB, storage: Optional[WalletStorage], *, config: SimpleConfig):
@@ -390,23 +389,7 @@ class Abstract_Eth_Wallet(ABC):
         """
         pass
 
-    @abstractmethod
-    def get_txin_type(self, address: str) -> str:
-        """Return script type of wallet address."""
-        pass
-
     def export_private_key(self, address: str, password: Optional[str]) -> str:
-        # if self.is_watching_only():
-        #     raise Exception(_("This is a watching-only wallet"))
-        # # if not is_address(address):
-        # #     raise Exception(f"Invalid bitcoin address: {address}")
-        # if not self.is_mine(address):
-        #     raise Exception(_('Address not in wallet.') + f' {address}')
-        # index = self.get_address_index(address)
-        # pk, compressed = self.keystore.get_private_key(index, password)
-        # txin_type = self.get_txin_type(address)
-        # serialized_privkey = bitcoin.serialize_privkey(pk, compressed, txin_type)
-        # return serialized_privkey
         pass
 
     def export_private_key_for_path(self, path: Union[Sequence[int], str], password: Optional[str]) -> str:
@@ -812,10 +795,6 @@ class Imported_Eth_Wallet(Simple_Eth_Wallet):
         else:
             raise BaseException("Not checksumaddr")
 
-    def get_txin_type(self, address):
-        pass
-        #return self.db.get_imported_address(address).get('type', 'address')
-
     def is_mine(self, address) -> bool:
         if not address: return False
         return self.db.has_imported_address(address)
@@ -857,17 +836,6 @@ class Imported_Eth_Wallet(Simple_Eth_Wallet):
         else:
             raise BaseException("Not checksumaddr")
             #raise BitcoinException(str(bad_keys[0][1]))
-
-    # def pubkeys_to_address(self, pubkeys):
-    #     pubkey = pubkeys[0]
-    #     for addr in self.db.get_imported_addresses():  # FIXME slow...
-    #         if self.db.get_imported_address(addr)['pubkey'] == pubkey:
-    #             return addr
-    #     return None
-
-    def get_txin_type(self, ):
-        print("11")
-        pass
 
     def decrypt_message(self, pubkey: str, message, password) -> bytes:
         # this is significantly faster than the implementation in the superclass
@@ -962,11 +930,7 @@ class Deterministic_Eth_Wallet(Abstract_Eth_Wallet):
         return self.pubkeys_to_address(pubkeys)
 
     def export_private_key_for_path(self, path: Union[Sequence[int], str], password: Optional[str]) -> str:
-        if isinstance(path, str):
-            path = convert_bip32_path_to_list_of_uint32(path)
-        pk, compressed = self.keystore.get_private_key(path, password)
-        txin_type = self.get_txin_type()  # assumes no mixed-scripts in wallet
-        return bitcoin.serialize_privkey(pk, compressed, txin_type)
+        pass
 
     def get_public_keys_with_deriv_info(self, address: str):
         der_suffix = self.get_address_index(address)
@@ -1046,10 +1010,6 @@ class Deterministic_Eth_Wallet(Abstract_Eth_Wallet):
     def get_device_info(self):
         return self.keystore.get_device_info()
 
-    def get_txin_type(self, address=None):
-        return self.txin_type
-
-
 class Simple_Eth_Deterministic_Wallet(Simple_Eth_Wallet, Deterministic_Eth_Wallet):
 
     """ Deterministic Wallet with a single pubkey per address """
@@ -1068,7 +1028,6 @@ class Simple_Eth_Deterministic_Wallet(Simple_Eth_Wallet, Deterministic_Eth_Walle
             xtype = bip32.xpub_type(self.keystore.xpub)
         except:
             xtype = 'eth_standard'
-        #self.txin_type = 'p2pkh' if xtype == 'standard' else xtype
 
     def get_master_public_key(self):
         return self.keystore.get_master_public_key()

--- a/electrum/eth_wallet.py
+++ b/electrum/eth_wallet.py
@@ -636,7 +636,8 @@ class Abstract_Eth_Wallet(ABC):
 
     def sign_message(self, address, message, password):
         index = self.get_address_index(address)
-        return self.keystore.sign_message(index, message, password)
+        coin = self.wallet_type.split('_')[0]
+        return self.keystore.sign_message(index, message, password, coin=coin)
 
     def decrypt_message(self, pubkey: str, message, password) -> bytes:
         addr = self.pubkeys_to_address([pubkey])

--- a/electrum/keystore.py
+++ b/electrum/keystore.py
@@ -127,7 +127,7 @@ class KeyStore(Logger, ABC):
         pass
 
     @abstractmethod
-    def sign_message(self, sequence: 'AddressIndexGeneric', message, password) -> bytes:
+    def sign_message(self, sequence: 'AddressIndexGeneric', message, password, coin=None, txin_type=None) -> bytes:
         pass
 
     @abstractmethod
@@ -172,7 +172,7 @@ class Software_KeyStore(KeyStore):
     def may_have_password(self):
         return not self.is_watching_only()
 
-    def sign_message(self, sequence, message, password) -> bytes:
+    def sign_message(self, sequence, message, password, coin=None, txin_type=None) -> bytes:
         privkey, compressed = self.get_private_key(sequence, password)
         key = ecc.ECPrivkey(privkey)
         return key.sign_message(message, compressed)

--- a/electrum/plugins/trezor/clientbase.py
+++ b/electrum/plugins/trezor/clientbase.py
@@ -274,15 +274,39 @@ class TrezorClientBase(HardwareClientBase, Logger):
                     show_display=True,
                     multisig=multisig)
 
-    def sign_message(self, address_str, message):
-        coin_name = self.plugin.get_coin_name()
+    def verify_message(self, address_str, message, sign_info, coin='btc'):
+        with self.run_flow():
+            if coin == "btc":
+                coin_name = self.plugin.get_coin_name()
+                return trezorlib.btc.verify_message(
+                    self.client,
+                    signature=sign_info,
+                    coin_name=coin_name,
+                    address=address_str,
+                    message=message)
+            else:
+                return trezorlib.ethereum.verify_message(
+                    self.client,
+                    address=address_str,
+                    signature=sign_info,
+                    message=message)
+
+    def sign_message(self, address_str, message, script_type=None, coin='btc'):
         address_n = parse_path(address_str)
         with self.run_flow():
-            return trezorlib.btc.sign_message(
-                self.client,
-                coin_name,
-                address_n,
-                message)
+            if coin == "btc":
+                coin_name = self.plugin.get_coin_name()
+                return trezorlib.btc.sign_message(
+                    self.client,
+                    coin_name,
+                    address_n,
+                    message,
+                    script_type=script_type)
+            else:
+                return trezorlib.ethereum.sign_message(
+                    self.client,
+                    address_n,
+                    message)
 
     def recover_device(self, recovery_type, *args, **kwargs):
         input_callback = self.mnemonic_callback(recovery_type)

--- a/electrum/plugins/trezor/trezor.py
+++ b/electrum/plugins/trezor/trezor.py
@@ -75,7 +75,7 @@ class TrezorKeyStore(Hardware_KeyStore):
     def decrypt_message(self, sequence, message, password):
         raise UserFacingException(_('Encryption and decryption are not implemented by {}').format(self.device))
 
-    def sign_message(self, sequence, message, password):
+    def sign_message(self, sequence, message, password, coin='btc', txin_type=None):
         if not self.plugin.client:
             raise Exception("client is None")
         xpub = self.xpub
@@ -83,7 +83,10 @@ class TrezorKeyStore(Hardware_KeyStore):
         if not self.plugin.force_pair_with_xpub(self.plugin.client, xpub, derivation):
             raise Exception("Can't Pair With You Device")
         address_path = self.get_derivation_prefix() + "/%d/%d" % sequence
-        msg_sig = self.plugin.client.sign_message(address_path, message)
+        script_type = None
+        if coin == 'btc':
+            script_type = self.plugin.get_trezor_input_script_type(txin_type)
+        msg_sig = self.plugin.client.sign_message(address_path, message, coin=coin, script_type=script_type)
         return msg_sig.signature
 
     def sign_transaction(self, tx, password):

--- a/electrum/util.py
+++ b/electrum/util.py
@@ -143,11 +143,15 @@ class NotSupportExportSeed(Exception):
     def __str__(self):
         return _("Current wallet does not support exporting Mnemonic.")
 
-class UnavailableBtcAddr(Exception):
+class UnsupportedCurrencyCoin(BaseException):
+    def __str__(self):
+        return _("Unsupported coin types.")
+
+class UnavailableBtcAddr(BaseException):
     def __str__(self):
         return _("Incorrect bitcoin address.")
 
-class UnavailableEthAddr(Exception):
+class UnavailableEthAddr(BaseException):
     def __str__(self):
         return _("Incorrect eth address.")
 

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -1988,7 +1988,7 @@ class Abstract_Wallet(AddressSynchronizer, ABC):
 
     def sign_message(self, address, message, password):
         index = self.get_address_index(address)
-        return self.keystore.sign_message(index, message, password)
+        return self.keystore.sign_message(index, message, password, coin='btc', txin_type=self.txin_type)
 
     def decrypt_message(self, pubkey: str, message, password) -> bytes:
         addr = self.pubkeys_to_address([pubkey])


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
1.ETH/BTC增加签名消息和验证消息接口
2.整理eth_wallet删除 一些不使用的代码

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
https://github.com/OneKeyHQ/TaskHub/issues/184

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
Python

## Any other comments?
…
