### PR TITLE
Click on the details page for all assets

### DIFF
--- a/android/app/src/main/java/org/haobtc/onekey/adapter/HdWalletAssetAdapter.kt
+++ b/android/app/src/main/java/org/haobtc/onekey/adapter/HdWalletAssetAdapter.kt
@@ -43,6 +43,7 @@ class HdWalletAssetAdapter(context: Context, data: List<WalletBalanceBean?>?) : 
     if (!Strings.isNullOrEmpty(strFiat)) {
       helper.setText(R.id.text_fiat, "≈ " + mSystemConfigManager.currentFiatSymbol + " " + strFiat)
     }
+
   }
 
 }

--- a/android/app/src/main/java/org/haobtc/onekey/onekeys/homepage/mindmenu/AllAssetsActivity.java
+++ b/android/app/src/main/java/org/haobtc/onekey/onekeys/homepage/mindmenu/AllAssetsActivity.java
@@ -27,6 +27,7 @@ import org.haobtc.onekey.bean.PyResponse;
 import org.haobtc.onekey.business.wallet.BalanceManager;
 import org.haobtc.onekey.business.wallet.SystemConfigManager;
 import org.haobtc.onekey.business.wallet.bean.WalletBalanceBean;
+import org.haobtc.onekey.onekeys.homepage.process.HdWalletDetailActivity;
 
 public class AllAssetsActivity extends BaseActivity implements TextWatcher {
 
@@ -113,6 +114,16 @@ public class AllAssetsActivity extends BaseActivity implements TextWatcher {
                                                     new HdWalletAssetAdapter(
                                                             getBaseContext(), walletInfo);
                                             reclAssets.setAdapter(hdWalletAssetAdapter);
+                                            hdWalletAssetAdapter.setOnItemClickListener(
+                                                    (adapter, view, position) -> {
+                                                        WalletBalanceBean walletBalanceBean =
+                                                                (WalletBalanceBean)
+                                                                        adapter.getData()
+                                                                                .get(position);
+                                                        String name = walletBalanceBean.getName();
+                                                        HdWalletDetailActivity.start(
+                                                                mContext, name);
+                                                    });
                                         }
                                     } else {
                                         tetNone.setVisibility(View.VISIBLE);

--- a/android/app/src/main/java/org/haobtc/onekey/onekeys/homepage/process/HdWalletDetailActivity.java
+++ b/android/app/src/main/java/org/haobtc/onekey/onekeys/homepage/process/HdWalletDetailActivity.java
@@ -73,6 +73,7 @@ public class HdWalletDetailActivity extends BaseActivity {
     private static final int REQUEST_PASSWORD_EXPORT_PRIVATE_KEY = 0x2 | REQUEST_PASSWORD_TAG;
     private static final int REQUEST_PASSWORD_EXPORT_KEYSTORE = 0x3 | REQUEST_PASSWORD_TAG;
     private static final int REQUEST_PASSWORD_DELETE_HD_DERIVED = 0x4 | REQUEST_PASSWORD_TAG;
+    private static final String WALLET_NAME = "hdWalletName";
 
     @BindView(R.id.img_token_logo)
     ImageView mImageTokenLogo;
@@ -142,6 +143,12 @@ public class HdWalletDetailActivity extends BaseActivity {
         ButterKnife.bind(this);
         EventBus.getDefault().register(this);
         inits();
+    }
+
+    public static void start(Context context, String name) {
+        Intent intent = new Intent(context, HdWalletDetailActivity.class);
+        intent.putExtra(WALLET_NAME, name);
+        context.startActivity(intent);
     }
 
     private void inits() {

--- a/android/app/src/main/res/layout/fragment_choose_import_mode.xml
+++ b/android/app/src/main/res/layout/fragment_choose_import_mode.xml
@@ -72,9 +72,12 @@
             android:layout_toEndOf="@+id/token_btc"
             android:text="@string/import_private"
             android:textColor="@color/text_two"
-            android:textSize="@dimen/sp_16" />
+            android:textSize="@dimen/sp_16"
+            android:layout_toRightOf="@+id/private_key_tex"
+            android:layout_marginEnd="@dimen/dp_15"/>
 
         <ImageView
+            android:id="@+id/private_key_tex"
             android:layout_width="@dimen/dp_25"
             android:layout_height="@dimen/dp_25"
             android:layout_alignParentEnd="true"


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
资产页面点击账户进入详情页，和首页点击详情流程一样
导入私钥 英文环境时，文字与图表重叠
## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
OneKeyHQ/TaskHub#822
OneKeyHQ/TaskHub#530

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
…

## Any other comments?
…
