### PR TITLE
Separate signature and verification interface for eth

### DIFF
--- a/electrum/eth_wallet.py
+++ b/electrum/eth_wallet.py
@@ -634,10 +634,9 @@ class Abstract_Eth_Wallet(ABC):
     def _update_password_for_keystore(self, old_pw: Optional[str], new_pw: Optional[str]) -> None:
         pass
 
-    def sign_message(self, address, message, password):
+    def sign_eth_message(self, address, message, password):
         index = self.get_address_index(address)
-        coin = self.wallet_type.split('_')[0]
-        return self.keystore.sign_message(index, message, password, coin=coin)
+        return self.keystore.sign_eth_message(index, message, password)
 
     def decrypt_message(self, pubkey: str, message, password) -> bytes:
         addr = self.pubkeys_to_address([pubkey])
@@ -944,7 +943,7 @@ class Deterministic_Eth_Wallet(Abstract_Eth_Wallet):
         assert type(for_change) is bool
         with self.lock:
             address = self.derive_address(int(for_change), index)
-            self.db.add_change_address(address) if for_change else self.db.add_receiving_address(address, index=index)
+            self.db.add_receiving_address(address, index=index)
             self.set_address_index(index)
            # self.add_address(address)
             if for_change:

--- a/electrum/keystore.py
+++ b/electrum/keystore.py
@@ -127,7 +127,7 @@ class KeyStore(Logger, ABC):
         pass
 
     @abstractmethod
-    def sign_message(self, sequence: 'AddressIndexGeneric', message, password, coin=None, txin_type=None) -> bytes:
+    def sign_message(self, sequence: 'AddressIndexGeneric', message, password,txin_type=None) -> bytes:
         pass
 
     @abstractmethod
@@ -172,7 +172,7 @@ class Software_KeyStore(KeyStore):
     def may_have_password(self):
         return not self.is_watching_only()
 
-    def sign_message(self, sequence, message, password, coin=None, txin_type=None) -> bytes:
+    def sign_message(self, sequence, message, password, txin_type=None) -> bytes:
         privkey, compressed = self.get_private_key(sequence, password)
         key = ecc.ECPrivkey(privkey)
         return key.sign_message(message, compressed)

--- a/electrum/plugins/trezor/clientbase.py
+++ b/electrum/plugins/trezor/clientbase.py
@@ -274,39 +274,43 @@ class TrezorClientBase(HardwareClientBase, Logger):
                     show_display=True,
                     multisig=multisig)
 
-    def verify_message(self, address_str, message, sign_info, coin='btc'):
+    def verify_message(self, address_str, message, sign_info):
         with self.run_flow():
-            if coin == "btc":
-                coin_name = self.plugin.get_coin_name()
-                return trezorlib.btc.verify_message(
-                    self.client,
-                    signature=sign_info,
-                    coin_name=coin_name,
-                    address=address_str,
-                    message=message)
-            else:
-                return trezorlib.ethereum.verify_message(
-                    self.client,
-                    address=address_str,
-                    signature=sign_info,
-                    message=message)
+            coin_name = self.plugin.get_coin_name()
+            return trezorlib.btc.verify_message(
+                self.client,
+                signature=sign_info,
+                coin_name=coin_name,
+                address=address_str,
+                message=message)
 
-    def sign_message(self, address_str, message, script_type=None, coin='btc'):
+    def verify_eth_message(self, address_str, message, sign_info):
+        with self.run_flow():
+            return trezorlib.ethereum.verify_message(
+                self.client,
+                address=address_str,
+                signature=sign_info,
+                message=message)
+
+    def sign_message(self, address_str, message, script_type=None):
+        address_n = parse_path(address_str)
+        coin_name = self.plugin.get_coin_name()
+        with self.run_flow():
+            return trezorlib.btc.sign_message(
+                self.client,
+                coin_name,
+                address_n,
+                message,
+                script_type=script_type)
+
+
+    def sign_eth_message(self, address_str, message):
         address_n = parse_path(address_str)
         with self.run_flow():
-            if coin == "btc":
-                coin_name = self.plugin.get_coin_name()
-                return trezorlib.btc.sign_message(
-                    self.client,
-                    coin_name,
-                    address_n,
-                    message,
-                    script_type=script_type)
-            else:
-                return trezorlib.ethereum.sign_message(
-                    self.client,
-                    address_n,
-                    message)
+            return trezorlib.ethereum.sign_message(
+                self.client,
+                address_n,
+                message)
 
     def recover_device(self, recovery_type, *args, **kwargs):
         input_callback = self.mnemonic_callback(recovery_type)

--- a/electrum/plugins/trezor/trezor.py
+++ b/electrum/plugins/trezor/trezor.py
@@ -75,7 +75,7 @@ class TrezorKeyStore(Hardware_KeyStore):
     def decrypt_message(self, sequence, message, password):
         raise UserFacingException(_('Encryption and decryption are not implemented by {}').format(self.device))
 
-    def sign_message(self, sequence, message, password, coin='btc', txin_type=None):
+    def sign_message(self, sequence, message, password, txin_type=None):
         if not self.plugin.client:
             raise Exception("client is None")
         xpub = self.xpub
@@ -83,10 +83,19 @@ class TrezorKeyStore(Hardware_KeyStore):
         if not self.plugin.force_pair_with_xpub(self.plugin.client, xpub, derivation):
             raise Exception("Can't Pair With You Device")
         address_path = self.get_derivation_prefix() + "/%d/%d" % sequence
-        script_type = None
-        if coin == 'btc':
-            script_type = self.plugin.get_trezor_input_script_type(txin_type)
-        msg_sig = self.plugin.client.sign_message(address_path, message, coin=coin, script_type=script_type)
+        script_type = self.plugin.get_trezor_input_script_type(txin_type)
+        msg_sig = self.plugin.client.sign_message(address_path, message, script_type=script_type)
+        return msg_sig.signature
+
+    def sign_eth_message(self, sequence, message, password):
+        if not self.plugin.client:
+            raise Exception("client is None")
+        xpub = self.xpub
+        derivation = self.get_derivation_prefix()
+        if not self.plugin.force_pair_with_xpub(self.plugin.client, xpub, derivation):
+            raise Exception("Can't Pair With You Device")
+        address_path = self.get_derivation_prefix() + "/%d/%d" % sequence
+        msg_sig = self.plugin.client.sign_eth_message(address_path, message)
         return msg_sig.signature
 
     def sign_transaction(self, tx, password):

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -1988,7 +1988,7 @@ class Abstract_Wallet(AddressSynchronizer, ABC):
 
     def sign_message(self, address, message, password):
         index = self.get_address_index(address)
-        return self.keystore.sign_message(index, message, password, coin='btc', txin_type=self.txin_type)
+        return self.keystore.sign_message(index, message, password, txin_type=self.txin_type)
 
     def decrypt_message(self, pubkey: str, message, password) -> bytes:
         addr = self.pubkeys_to_address([pubkey])

--- a/electrum/wallet_db.py
+++ b/electrum/wallet_db.py
@@ -1128,13 +1128,22 @@ class WalletDB(JsonDB):
             for name in ['receiving', 'change']:
                 if name not in self.data['addresses']:
                     self.data['addresses'][name] = []
+            coin = wallet_type.split("_")[0]
             self.change_addresses = self.data['addresses']['change']
             self.receiving_addresses = self.data['addresses']['receiving']
             self._addr_to_addr_index = {}  # type: Dict[str, Sequence[int]]  # key: address, value: (is_change, index)
-            for i, addr in enumerate(self.receiving_addresses):
-                self._addr_to_addr_index[addr] = (0, i)
             for i, addr in enumerate(self.change_addresses):
                 self._addr_to_addr_index[addr] = (1, i)
+
+            if coin == "standard":
+                for i, addr in enumerate(self.receiving_addresses):
+                    self._addr_to_addr_index[addr] = (0, i)
+            else:
+                index = 0
+                if len(self.receiving_addresses) != 0:
+                    if "address_index" in self.data:
+                        index = self.data["address_index"]
+                    self._addr_to_addr_index[self.receiving_addresses[0]] = (0, index)
 
     @profiler
     def _load_transactions(self):

--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -2049,7 +2049,7 @@ class AndroidCommands(commands.Commands):
             if coin in self.coins:
                 if not self.pywalib.web3.isAddress(address):
                     raise UnavailableEthAddr()
-            elif coin == 'standard':
+            elif coin == 'btc':
                 if not bitcoin.is_address(address):
                     raise UnavailableBtcAddr()
                 txin_type = self.wallet.get_txin_type(address)
@@ -2061,8 +2061,10 @@ class AndroidCommands(commands.Commands):
                 raise BaseException(_("This is a watching-only wallet."))
             if not self.wallet.is_mine(address):
                 raise BaseException(_("The address is not in the current wallet."))
-
-            sig = self.wallet.sign_message(address, message, password)
+            if coin == 'btc':
+                sig = self.wallet.sign_message(address, message, password)
+            else:
+                sig = self.wallet.sign_eth_message(address, message, password)
             import base64
 
             return base64.b64encode(sig).decode("ascii")
@@ -2092,7 +2094,10 @@ class AndroidCommands(commands.Commands):
             import base64
             sig = base64.b64decode(str(signature))
             client = self.get_client(path=path)
-            verified = client.verify_message(address, message, sig, coin=coin)
+            if coin == 'btc':
+                verified = client.verify_message(address, message, sig)
+            else:
+                verified = client.verify_eth_message(address, message, sig)
         except Exception:
             verified = False
         return verified


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
1.针对eth专门提取签名和验签接口
2.修复从第二个派生钱包开始核验地址错误的问题

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
https://github.com/OneKeyHQ/TaskHub/issues/848

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
Python

## Any other comments?
…
