### PR TITLE
Hardware split

### DIFF
--- a/electrum/plugins/trezor/clientbase.py
+++ b/electrum/plugins/trezor/clientbase.py
@@ -13,6 +13,7 @@ from electrum.plugins.hw_wallet.plugin import OutdatedHwFirmwareException, Hardw
 from trezorlib.client import TrezorClient, PASSPHRASE_ON_DEVICE
 from trezorlib.exceptions import TrezorFailure, Cancelled, OutdatedFirmwareError
 from trezorlib.messages import WordRequestType, RecoveryDeviceType, ButtonRequestType
+from trezorlib import protobuf as trezor_protobuf
 import trezorlib.btc
 import trezorlib.device
 from trezorlib.customer_ui import CustomerUI
@@ -93,6 +94,10 @@ class TrezorClientBase(HardwareClientBase, Logger):
     @property
     def features(self):
         return self.client.features
+
+    @property
+    def features_dict(self):
+        return trezor_protobuf.to_dict(self.features)
 
     def __str__(self):
         return "%s/%s" % (self.label(), self.features.device_id)

--- a/electrum/plugins/trezor/clientbase.py
+++ b/electrum/plugins/trezor/clientbase.py
@@ -1,5 +1,6 @@
 import time
 from struct import pack
+from typing import Tuple
 
 from electrum import ecc
 from electrum.i18n import _
@@ -159,6 +160,9 @@ class TrezorClientBase(HardwareClientBase, Logger):
                          fingerprint=self.i4b(node.fingerprint),
                          child_number=self.i4b(node.child_num)).to_xpub()
 
+    def apply_settings(self, **kwargs) -> str:
+        return trezorlib.device.apply_settings(self.client, **kwargs)
+
     def backup(self) -> str:
         if type == 1:
             msg = ("Confirm backup your {} device")
@@ -170,6 +174,10 @@ class TrezorClientBase(HardwareClientBase, Logger):
     def se_proxy(self, message) -> str:
         with self.run_flow(''):
             return trezorlib.device.se_proxy(self.client, message).hex()
+
+    def se_verify(self, digest: bytes) -> Tuple[str, str]:
+        resp = trezorlib.device.se_verify(self.client, digest)
+        return resp.cert.hex(), resp.signature.hex()
 
     def recovery(self, *args):
         with self.run_flow(''):

--- a/electrum/plugins/trezor/clientbase.py
+++ b/electrum/plugins/trezor/clientbase.py
@@ -4,7 +4,7 @@ from typing import Tuple
 
 from electrum import ecc
 from electrum.i18n import _
-from electrum.util import UserCancelled, UserFacingException
+from electrum.util import UserCancelled
 from electrum.keystore import bip39_normalize_passphrase
 from electrum.bip32 import BIP32Node, convert_bip32_path_to_list_of_uint32 as parse_path
 from electrum.logging import Logger
@@ -12,7 +12,7 @@ from electrum.plugins.hw_wallet.plugin import OutdatedHwFirmwareException, Hardw
 
 from trezorlib.client import TrezorClient, PASSPHRASE_ON_DEVICE
 from trezorlib.exceptions import TrezorFailure, Cancelled, OutdatedFirmwareError
-from trezorlib.messages import WordRequestType, FailureType, RecoveryDeviceType, ButtonRequestType
+from trezorlib.messages import WordRequestType, RecoveryDeviceType, ButtonRequestType
 import trezorlib.btc
 import trezorlib.device
 from trezorlib.customer_ui import CustomerUI
@@ -152,7 +152,7 @@ class TrezorClientBase(HardwareClientBase, Logger):
         address_n = parse_path(bip32_path)
         with self.run_flow(''):
             node = trezorlib.ethereum.get_public_node(self.client, address_n).node
-       # return node.xpub
+        # return node.xpub
         return BIP32Node(xtype='standard',
                          eckey=ecc.ECPubkey(node.public_key),
                          chaincode=node.chain_code,
@@ -164,10 +164,6 @@ class TrezorClientBase(HardwareClientBase, Logger):
         return trezorlib.device.apply_settings(self.client, **kwargs)
 
     def backup(self) -> str:
-        if type == 1:
-            msg = ("Confirm backup your {} device")
-        elif type == 2:
-            msg = ("Confirm recovry your {} device")
         with self.run_flow(''):
             return trezorlib.device.se_backup(self.client).hex()
 
@@ -311,7 +307,6 @@ class TrezorClientBase(HardwareClientBase, Logger):
                 message,
                 script_type=script_type)
 
-
     def sign_eth_message(self, address_str, message):
         address_n = parse_path(address_str)
         with self.run_flow():
@@ -375,7 +370,7 @@ class TrezorClientBase(HardwareClientBase, Logger):
                 msg = "3"
             else:
                 msg = (_("Re-enter the new PIN for your {}.\n\n"
-                     "NOTE: the positions of the numbers have changed!"))
+                         "NOTE: the positions of the numbers have changed!"))
         else:
             if isinstance(self.handler, CustomerUI):
                 msg = "1"
@@ -396,9 +391,9 @@ class TrezorClientBase(HardwareClientBase, Logger):
                 msg = "6"
             else:
                 msg = _("Enter a passphrase to generate this wallet.  Each time "
-                    "you use this wallet your {} will prompt you for the "
-                    "passphrase.  If you forget the passphrase you cannot "
-                    "access the bitcoins in the wallet.").format(self.device)
+                        "you use this wallet your {} will prompt you for the "
+                        "passphrase.  If you forget the passphrase you cannot "
+                        "access the bitcoins in the wallet.").format(self.device)
         else:
             if isinstance(self.handler, CustomerUI):
                 msg = "3"

--- a/electrum/plugins/trezor/clientbase.py
+++ b/electrum/plugins/trezor/clientbase.py
@@ -439,3 +439,20 @@ class TrezorClientBase(HardwareClientBase, Logger):
             return word
 
         return word_callback
+
+    def reboot_to_bootloader(self) -> bool:
+        """
+        Reboot the device to bootloader mode if needed.
+        :return: True if the device enters or is already in bootloader mode,
+                 False otherwise.
+        """
+        if not self.features.bootloader_mode:
+            try:
+                trezorlib.device.reboot(self.client)
+            except Exception:
+                return False
+            else:
+                time.sleep(2)
+                self.client.init_device()
+
+        return self.features.bootloader_mode

--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -3138,7 +3138,6 @@ class AndroidCommands(commands.Commands):
 
             temp_path = self.get_temp_file()
             path = self._wallet_path(temp_path)
-            self.get_keystores_info()  # TODO: is this required to ensure something?
             storage, db = self.wizard.create_storage(path=path, password="", hide_type=True, coin=coin)
             if storage:
                 if coin in self.coins:

--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -178,6 +178,7 @@ def verify_xpub(xpub: str) -> bool:
 # Adds additional commands which aren't available over JSON RPC.
 class AndroidCommands(commands.Commands):
     _recovery_flag = True
+
     def __init__(self, android_id=None, config=None, user_dir=None, callback=None, chain_type="mainnet"):
         self.asyncio_loop, self._stop_loop, self._loop_thread = create_and_start_event_loop()  # TODO:close loop
         self.config = self.init_config(config=config)
@@ -1377,7 +1378,7 @@ class AndroidCommands(commands.Commands):
                     addr = asyncio.run_coroutine_threadsafe(
                         self.gettransaction(txin.prevout.txid.hex(), txin.prevout.out_idx), self.network.asyncio_loop
                     ).result()
-                except BaseException as e:  # noqa
+                except BaseException:
                     addr = ""
             input_info["address"] = addr
             input_list.append(input_info)
@@ -2619,7 +2620,7 @@ class AndroidCommands(commands.Commands):
                     Account.decrypt(json.loads(data), password).hex()
                 except (TypeError, KeyError, NotImplementedError):
                     raise BaseException(_("Incorrect eth keystore."))
-                except BaseException as e:
+                except BaseException:
                     raise InvalidPassword()
 
             elif flag == "public":
@@ -3137,7 +3138,7 @@ class AndroidCommands(commands.Commands):
 
             temp_path = self.get_temp_file()
             path = self._wallet_path(temp_path)
-            keystores = self.get_keystores_info()
+            self.get_keystores_info()  # TODO: is this required to ensure something?
             storage, db = self.wizard.create_storage(path=path, password="", hide_type=True, coin=coin)
             if storage:
                 if coin in self.coins:
@@ -3532,7 +3533,7 @@ class AndroidCommands(commands.Commands):
             raise e
 
     def check_exist_file(self, wallet_obj):
-        for _, exist_wallet in self.daemon._wallets.items():  # noqa
+        for _path, exist_wallet in self.daemon._wallets.items():
             if wallet_obj.get_addresses()[0] in exist_wallet.get_addresses()[0]:
                 if exist_wallet.is_watching_only() and not wallet_obj.is_watching_only():
                     raise ReplaceWatchonlyWallet(exist_wallet)
@@ -3743,7 +3744,7 @@ class AndroidCommands(commands.Commands):
         try:
             self._assert_daemon_running()
             net_params = self.network.get_parameters()
-            host, port, _ = net_params.server.host, net_params.server.port, net_params.server.protocol
+            host, port = net_params.server.host, net_params.server.port
         except BaseException as e:
             raise e
 

--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -18,8 +18,6 @@ from eth_account import Account
 from eth_keys import keys
 from hexbytes import HexBytes
 from mnemonic import Mnemonic
-from trezorlib import device, exceptions, firmware, messages, protobuf
-from trezorlib.cli import trezorctl
 from trezorlib.customer_ui import CustomerUI
 
 from electrum import MutiBase, bitcoin, commands, constants, daemon, ecc, keystore, paymentrequest, simple_config, util
@@ -75,9 +73,10 @@ from electrum.wallet import Imported_Wallet, Standard_Wallet, Wallet
 from electrum.wallet_db import WalletDB
 from electrum_gui.common import the_begging
 
+from electrum_gui.android import hardware
+
 from .create_wallet_info import CreateWalletInfo
 from .derived_info import DerivedInfo
-from .firmware_sign_nordic_dfu import parse
 from .tx_db import TxDb
 
 log_info = logging.getLogger(__name__)
@@ -223,7 +222,6 @@ class AndroidCommands(commands.Commands):
             ran_str = "".join(random.sample(string.ascii_letters + string.digits, 8))
             self.config.set_key("ra_str", ran_str)
         self.android_id = android_id + ran_str
-        self.lock = threading.RLock()
         self.init_local_wallet_info()
         if self.network:
             interests = [
@@ -270,6 +268,14 @@ class AndroidCommands(commands.Commands):
         self.start_daemon()
         self.get_block_info()
         the_begging.initialize()
+
+        self.trezor_manager = hardware.TrezorManager(self.plugin)
+
+    def __getattr__(self, name):
+        if name in self.trezor_manager.exposed_commands:
+            return getattr(self.trezor_manager, name)
+
+        raise AttributeError
 
     def init_config(self, config=None):
         config_options = {}
@@ -2042,7 +2048,7 @@ class AndroidCommands(commands.Commands):
         """
         try:
             if path:
-                self.get_client(path=path)
+                self.trezor_manager.ensure_client(path)
             self._assert_wallet_isvalid()
             address = address.strip()
             message = message.strip()
@@ -2092,7 +2098,7 @@ class AndroidCommands(commands.Commands):
             # This can throw on invalid base64
             import base64
             sig = base64.b64decode(str(signature))
-            client = self.get_client(path=path)
+            self.trezor_manager.ensure_client(path)
             verified = self.wallet.verify_message(address, message, sig)
         except Exception:
             verified = False
@@ -2189,7 +2195,7 @@ class AndroidCommands(commands.Commands):
         """
         try:
             if path is not None:
-                self.get_client(path=path)
+                self.trezor_manager.ensure_client(path)
             self._assert_wallet_isvalid()
             tx = tx_from_any(tx)
             tx.deserialize()
@@ -2221,193 +2227,6 @@ class AndroidCommands(commands.Commands):
         except BaseException as e:
             raise e
 
-    def hardware_verify(self, msg, path="android_usb") -> str:
-        """
-        Anti-counterfeiting verification, used by hardware
-        :param msg: msg as str
-        :param path: NFC/android_usb/bluetooth as str
-        :return: json like {'serialno': 'Bixin20051500293', 'is_bixinkey': 'True', 'is_verified': 'True', 'last_check_time': 1611904981}
-        """
-        client = self.get_client(path=path)
-        try:
-            from hashlib import sha256
-
-            digest = sha256(msg.encode("utf-8")).digest()
-            response = device.se_verify(client.client, digest)
-        except Exception as e:
-            raise BaseException(e)
-        params = {"data": msg, "cert": response.cert.hex(), "signature": response.signature.hex()}
-        verify_url = "https://key.bixin.com/lengqian.bo/"
-        import requests
-
-        try:
-            res = requests.post(verify_url, data=params, timeout=30)
-        except Exception as e:
-            raise BaseException(_(str(e))) from e
-        else:
-            return res.text
-
-    def backup_wallet(self, path="android_usb"):
-        """
-        Backup wallet by se
-        :param path: NFC/android_usb/bluetooth as str, used by hardware
-        :return:
-        """
-        client = self.get_client(path=path)
-        try:
-            response = client.backup()
-        except Exception as e:
-            raise BaseException(e)
-        return response
-
-    def se_proxy(self, message, path="android_usb") -> str:
-        client = self.get_client(path=path)
-        try:
-            response = client.se_proxy(message)
-        except Exception as e:
-            raise BaseException(e)
-        return response
-
-    def bixin_backup_device(self, path="android_usb"):
-        """
-        Export seed, used by hardware
-        :param path: NFC/android_usb/bluetooth as str
-        :return: as string
-        """
-        client = self.get_client(path=path)
-        try:
-            response = client.bixin_backup_device()
-        except Exception as e:
-            raise BaseException(e)
-        return response
-
-    def bixin_load_device(self, path="android_usb", mnemonics=None, language="en-US", label="BIXIN KEY"):
-        """
-        Import seed, used by hardware
-        :param mnemonics: as string
-        :param path: NFC/android_usb/bluetooth as str
-        :return: raise except if error
-        """
-        client = self.get_client(path=path)
-        try:
-            response = client.bixin_load_device(mnemonics=mnemonics, language=language, label=label)
-        except Exception as e:
-            raise BaseException(e)
-        return response
-
-    def recovery_wallet_hw(self, path="android_usb", *args):
-        """
-        Recovery wallet by encryption
-        :param path: NFC/android_usb/bluetooth as str, used by hardware
-        :param args: encryption data as str
-        :return:
-        """
-        client = self.get_client(path=path)
-        try:
-            response = client.recovery(*args)
-        except Exception as e:
-            raise BaseException(e)
-        return response
-
-    def bx_inquire_whitelist(self, path="android_usb", **kwargs):
-        """
-        Inquire
-        :param path: NFC/android_usb/bluetooth as str, used by hardware
-        :param kwargs:
-            type:2=inquire
-            addr_in: addreess as str
-        :return:
-        """
-        client = self.get_client(path=path)
-        try:
-            response = json.dumps(client.bx_inquire_whitelist(**kwargs))
-        except Exception as e:
-            raise BaseException(e)
-        return response
-
-    def bx_add_or_delete_whitelist(self, path="android_usb", **kwargs):
-        """
-        Add and delete whitelist
-        :param path: NFC/android_usb/bluetooth as str, used by hardware
-        :param kwargs:
-            type:0=add 1=delete
-            addr_in: addreess as str
-        :return:
-        """
-        client = self.get_client(path=path)
-        try:
-            response = json.dumps(client.bx_add_or_delete_whitelist(**kwargs))
-        except Exception as e:
-            raise BaseException(e)
-        return response
-
-    def apply_setting(self, path="nfc", **kwargs):
-        """
-        Set the hardware function, used by hardware
-        :param path: NFC/android_usb/bluetooth as str
-        :param kwargs:
-            label="wangls"
-            language="chinese/english"
-            use_passphrase=true/false
-            auto_lock_delay_ms="600"
-            use_ble=true/false
-            use_se=true/false
-            is_bixinapp=true/false
-        :return:0/1
-        """
-        client = self.get_client(path=path)
-        try:
-            resp = device.apply_settings(client.client, **kwargs)
-            if resp == "Settings applied":
-                return 1
-            else:
-                return 0
-        except Exception as e:
-            raise BaseException(e)
-
-    def init(self, path="android_usb", label="BIXIN KEY", language="english", stronger_mnemonic=None, use_se=False):
-        """
-        Activate the device, used by hardware
-        :param stronger_mnemonic: if not None 256  else 128
-        :param path: NFC/android_usb/bluetooth as str
-        :param label: name as string
-        :param language: as string
-        :param use_se: as bool
-        :return:0/1
-        """
-        client = self.get_client(path=path)
-        strength = 128
-        try:
-            if use_se:
-                device.apply_settings(client.client, use_se=True)
-            if stronger_mnemonic:
-                strength = 256
-            response = client.reset_device(
-                language=language, passphrase_protection=True, label=label, strength=strength
-            )
-        except Exception as e:
-            raise BaseException(e)
-        if response == "Device successfully initialized":
-            return 1
-        else:
-            return 0
-
-    def reset_pin(self, path="android_usb") -> int:
-        """
-        Reset pin, used by hardware
-        :param path:NFC/android_usb/bluetooth as str
-        :return:0/1
-        """
-        try:
-            client = self.get_client(path)
-            client.set_pin(False)
-        except Exception as e:
-            if isinstance(e, exceptions.PinException) or isinstance(e, RuntimeError):
-                return 0
-            else:
-                raise BaseException("user cancel")
-        return 1
-
     def show_address(self, address, path="android_usb", coin="btc") -> str:
         """
         Verify address on hardware, used by hardware
@@ -2416,101 +2235,19 @@ class AndroidCommands(commands.Commands):
         :return:1/except
         """
         try:
-            plugin = self.plugin.get_plugin("trezor")
-            plugin.show_address(path=path, ui=CustomerUI(), wallet=self.wallet, address=address, coin=coin)
+            self.trezor_manager.plugin.show_address(
+                path=path,
+                ui=CustomerUI(),
+                wallet=self.wallet,
+                address=address,
+                coin=coin
+            )
             return "1"
         except Exception as e:
             raise BaseException(e)
 
-    def wipe_device(self, path="android_usb") -> int:
-        """
-        Reset device, used by hardware
-        :param path: NFC/android_usb/bluetooth as str
-        :return:0/1
-        """
-        try:
-            client = self.get_client(path)
-            resp = client.wipe_device()
-        except Exception as e:
-            if isinstance(e, exceptions.PinException) or isinstance(e, RuntimeError):
-                return 0
-            else:
-                raise BaseException(str(e)) from e
-        if resp == "Device wiped":
-            return 1
-        else:
-            return 0
-
-    def get_passphrase_status(self, path="android_usb"):
-        # self.client = None
-        # self.path = ''
-        client = self.get_client(path=path)
-        return client.features.passphrase_protection
-
-    def get_client(self, path="android_usb", ui=CustomerUI(), clean=False):
-        plugin = self.plugin.get_plugin("trezor")
-        if clean:
-            plugin.clean()
-        return plugin.get_client(path=path, ui=ui)
-
     def is_encrypted_with_hw_device(self):
         self.wallet.storage.is_encrypted_with_hw_device()
-
-    def get_feature(self, path="android_usb"):
-        """
-        Get hardware information, used by hardware
-        :param path: NFC/android_usb/bluetooth as str
-        :return: dict like:
-            {capabilities: List[EnumTypeCapability] = None,
-            vendor: str = None,
-            major_version: int = None,  主版本号
-            minor_version: int = None,  次版本号
-            patch_version: int = None,  修订号    硬件的软件版本(俗称固件，在2.0.1 之前使用)
-            bootloader_mode: bool = None,  设备当时是不是在bootloader模式
-            device_id: str = None,  设备唯一标识，设备恢复出厂设置这个值会变
-            pin_protection: bool = None, 是否开启了PIN码保护，
-            passphrase_protection: bool = None, 是否开启了passphrase功能,这个用来支持创建隐藏钱包
-            language: str = None,
-            label: str = None,  激活钱包时，使用的名字
-            initialized: bool = None, 当时设备是否激活
-            revision: bytes = None,
-            bootloader_hash: bytes = None,
-            imported: bool = None,
-            unlocked: bool = None,
-            firmware_present: bool = None,
-            needs_backup: bool = None,
-            flags: int = None,
-            model: str = None,
-            fw_major: int = None,
-            fw_minor: int = None,
-            fw_patch: int = None,
-            fw_vendor: str = None,
-            fw_vendor_keys: bytes = None,
-            unfinished_backup: bool = None,
-            no_backup: bool = None,
-            recovery_mode: bool = None,
-            backup_type: EnumTypeBackupType = None,
-            sd_card_present: bool = None,
-            sd_protection: bool = None,
-            wipe_code_protection: bool = None,
-            session_id: bytes = None,
-            passphrase_always_on_device: bool = None,
-            safety_checks: EnumTypeSafetyCheckLevel = None,
-            auto_lock_delay_ms: int = None, 自动关机时间
-            display_rotation: int = None,
-            experimental_features: bool = None,
-            offset: int = None,  升级时断点续传使用的字段
-            ble_name: str = None,
-            ble_ver: str = None,  蓝牙固件版本
-            ble_enable: bool = None,
-            se_enable: bool = None,
-            se_ver: str = None,  se的版本
-            backup_only: bool = None,  是否是特殊设备，只用来备份，没有额外功能支持
-            onekey_version: str = None,  硬件的软件版本（俗称固件），仅供APP使用（从2.0.1开始加入）}
-        """
-        with self.lock:
-            client = self.get_client(path=path, clean=True)
-        return json.dumps(protobuf.to_dict(client.features))
 
     def get_xpub_from_hw(self, path="android_usb", _type="p2wpkh", is_creating=True, account_id=None, coin="btc"):
         """
@@ -2520,12 +2257,11 @@ class AndroidCommands(commands.Commands):
         :coin: btc/eth as string
         :return: xpub string
         """
-        client = self.get_client(path=path)
-        self.hw_info["device_id"] = client.features.device_id
-        self.hw_info["type"] = _type
+        self.hw_info["device_id"] = self.trezor_manager.get_device_id(path)
         if account_id is None:
             account_id = 0
         if coin == "btc":
+            self.hw_info["type"] = _type
             if _type == "p2wsh":
                 derivation = purpose48_derivation(account_id, xtype="p2wsh")
                 self.hw_info["type"] = 48
@@ -2539,23 +2275,19 @@ class AndroidCommands(commands.Commands):
             elif _type == "p2wpkh-p2sh":
                 derivation = bip44_derivation(account_id, bip43_purpose=49)
                 self.hw_info["type"] = 49
-            try:
-                xpub = client.get_xpub(derivation, _type, creating=is_creating)
-            except Exception as e:
-                raise BaseException(e)
-            return xpub
+            xpub = self.trezor_manager.get_xpub(
+                path, derivation, _type, is_creating
+            )
         else:
+            self.hw_info["type"] = self.coins[coin]["addressType"]
             derivation = bip44_eth_derivation(
                 account_id, bip43_purpose=self.coins[coin]["addressType"], cointype=self.coins[coin]["coinId"]
             )
 
             derivation = util.get_keystore_path(derivation)
-            try:
-                xpub = client.get_eth_xpub(derivation)
-                self.hw_info["type"] = self.coins[coin]["addressType"]
-            except Exception as e:
-                raise BaseException(e)
-            return xpub
+            xpub = self.trezor_manager.get_eth_xpub(path, derivation)
+
+        return xpub
 
     def create_hw_derived_wallet(self, path="android_usb", _type="p2wpkh", is_creating=True, coin="btc"):
         """
@@ -2577,88 +2309,6 @@ class AndroidCommands(commands.Commands):
         dervied_xpub = self.get_xpub_from_hw(path=path, _type=_type, account_id=list_info[0], coin=coin)
         self.hw_info["account_id"] = list_info[0]
         return dervied_xpub
-
-    def firmware_update(  # noqa
-        self,
-        filename,
-        path,
-        type="",
-        fingerprint=None,
-        skip_check=True,
-        raw=False,
-        dry_run=False,
-    ):
-        """
-        Upload new firmware to device.used by hardware
-        Note : Device must be in bootloader mode.
-        :param filename: full path to local upgrade file
-        :param path: NFC/android_usb/bluetooth as str
-        :return: None
-        """
-        # self.client = None
-        # self.path = ''
-        client = self.get_client(path)
-        features = client.features
-        if not features.bootloader_mode:
-            resp = client.client.call(messages.BixinReboot())
-            if not dry_run and not isinstance(resp, messages.Success):
-                raise RuntimeError("Failed turn into bootloader")
-            time.sleep(2)
-            client.client.init_device()
-        if not dry_run and not client.features.bootloader_mode:
-            raise BaseException(_("Switch the device to bootloader mode."))
-
-        bootloader_onev2 = features.major_version == 1 and features.minor_version >= 8
-
-        if filename:
-            try:
-                if type:
-                    data = parse(filename)
-                else:
-                    with open(filename, "rb") as file:
-                        data = file.read()
-            except Exception as e:
-                raise BaseException(e)
-        else:
-            raise BaseException(("Please give the file name"))
-
-        if not raw and not skip_check:
-            try:
-                version, fw = firmware.parse(data)
-            except Exception as e:
-                raise BaseException(e)
-
-            trezorctl.validate_firmware(version, fw, fingerprint)
-            if bootloader_onev2 and version == firmware.FirmwareFormat.TREZOR_ONE and not fw.embedded_onev2:
-                raise BaseException(_("Your device's firmware version is too low. Aborting."))
-            elif not bootloader_onev2 and version == firmware.FirmwareFormat.TREZOR_ONE_V2:
-                raise BaseException(_("You need to upgrade the bootloader immediately."))
-
-            if features.major_version not in trezorctl.ALLOWED_FIRMWARE_FORMATS:
-                raise BaseException(("Trezorctl doesn't know your device version. Aborting."))
-            elif version not in trezorctl.ALLOWED_FIRMWARE_FORMATS[features.major_version]:
-                raise BaseException(_("Firmware not compatible with your equipment, Aborting."))
-
-        if not raw:
-            # special handling for embedded-OneV2 format:
-            # for bootloader < 1.8, keep the embedding
-            # for bootloader 1.8.0 and up, strip the old OneV1 header
-            if bootloader_onev2 and data[:4] == b"TRZR" and data[256 : 256 + 4] == b"TRZF":
-                print("Extracting embedded firmware image (fingerprint may change).")
-                data = data[256:]
-
-        if dry_run:
-            print("Dry run. Not uploading firmware to device.")
-        else:
-            try:
-                if features.major_version == 1 and features.firmware_present is not False:
-                    # Trezor One does not send ButtonRequest
-                    print("Please confirm the action on your Trezor device")
-                return firmware.update(client.client, data, type=type)
-            except exceptions.Cancelled:
-                print("Update aborted on device.")
-            except exceptions.TrezorException as e:
-                raise BaseException(_("Update failed: {}".format(e)))
 
     def export_keystore(self, password):
         """

--- a/electrum_gui/android/hardware.py
+++ b/electrum_gui/android/hardware.py
@@ -24,7 +24,7 @@ from electrum_gui.android import firmware_sign_nordic_dfu
 TREZOR_PLUGIN_NAME = 'trezor'
 
 
-def _reboot_to_bootloader(client, dry_run=False):
+def _reboot_to_bootloader(client: trezor_clientbase.TrezorClientBase, dry_run: bool = False) -> None:
     if client.features.bootloader_mode:
         return
 
@@ -41,7 +41,9 @@ def _reboot_to_bootloader(client, dry_run=False):
     raise BaseException(_("Switch the device to bootloader mode."))
 
 
-def _do_firmware_update(client, data, type, dry_run=False):
+def _do_firmware_update(
+    client: trezor_clientbase.TrezorClientBase, data: bytes, type: str, dry_run: bool = False
+) -> None:
     if dry_run:
         print("Dry run. Not uploading firmware to device.")
         return
@@ -131,17 +133,17 @@ class TrezorManager(object):
         client = self._get_client(path)
         return client.features.device_id
 
-    def get_xpub(self, path, derivation, _type, creating):
+    def get_xpub(self, path: str, derivation: str, _type: str, creating: bool) -> str:
         return self._bridge(path, 'get_xpub', derivation, _type, creating=creating)
 
-    def get_eth_xpub(self, path, derivation):
+    def get_eth_xpub(self, path: str, derivation: str) -> str:
         return self._bridge(path, 'get_eth_xpub', derivation)
 
     # === End helper methods used in console.AndroidCommands ===
 
     # Below are exposed methods, would be directly called from the upper users.
 
-    def hardware_verify(self, msg, path="android_usb") -> str:
+    def hardware_verify(self, msg: str, path: str = "android_usb") -> str:
         """
         Anti-counterfeiting verification, used by hardware
         :param msg: msg as str
@@ -172,7 +174,7 @@ class TrezorManager(object):
         else:
             return res.text
 
-    def backup_wallet(self, path="android_usb"):
+    def backup_wallet(self, path: str = "android_usb") -> str:
         """
         Backup wallet by se
         :param path: NFC/android_usb/bluetooth as str, used by hardware
@@ -180,10 +182,10 @@ class TrezorManager(object):
         """
         return self._bridge(path, 'backup')
 
-    def se_proxy(self, message, path="android_usb") -> str:
+    def se_proxy(self, message: str, path: str = "android_usb") -> str:
         return self._bridge(path, 'se_proxy', message)
 
-    def bixin_backup_device(self, path="android_usb"):
+    def bixin_backup_device(self, path: str = "android_usb") -> str:
         """
         Export seed, used by hardware
         :param path: NFC/android_usb/bluetooth as str
@@ -191,7 +193,13 @@ class TrezorManager(object):
         """
         return self._bridge(path, 'bixin_backup_device')
 
-    def bixin_load_device(self, path="android_usb", mnemonics=None, language="en-US", label="BIXIN KEY"):
+    def bixin_load_device(
+        self,
+        path: str = "android_usb",
+        mnemonics: Optional[str] = None,
+        language: str = "en-US",
+        label: str = "BIXIN KEY",
+    ) -> str:
         """
         Import seed, used by hardware
         :param mnemonics: as string
@@ -200,7 +208,7 @@ class TrezorManager(object):
         """
         return self._bridge(path, 'bixin_load_device', mnemonics=mnemonics, language=language, label=label)
 
-    def recovery_wallet_hw(self, path="android_usb", *args):
+    def recovery_wallet_hw(self, path: str = "android_usb", *args) -> str:
         """
         Recovery wallet by encryption
         :param path: NFC/android_usb/bluetooth as str, used by hardware
@@ -209,7 +217,7 @@ class TrezorManager(object):
         """
         return self._bridge(path, 'recovery', *args)
 
-    def bx_inquire_whitelist(self, path="android_usb", **kwargs):
+    def bx_inquire_whitelist(self, path: str = "android_usb", **kwargs) -> str:
         """
         Inquire
         :param path: NFC/android_usb/bluetooth as str, used by hardware
@@ -220,7 +228,7 @@ class TrezorManager(object):
         """
         return self._json_bridge(path, 'bx_inquire_whitelist', **kwargs)
 
-    def bx_add_or_delete_whitelist(self, path="android_usb", **kwargs):
+    def bx_add_or_delete_whitelist(self, path: str = "android_usb", **kwargs) -> str:
         """
         Add and delete whitelist
         :param path: NFC/android_usb/bluetooth as str, used by hardware
@@ -231,7 +239,7 @@ class TrezorManager(object):
         """
         return self._json_bridge(path, 'bx_add_or_delete_whitelist', **kwargs)
 
-    def apply_setting(self, path="nfc", **kwargs):
+    def apply_setting(self, path: str = "nfc", **kwargs) -> int:
         """
         Set the hardware function, used by hardware
         :param path: NFC/android_usb/bluetooth as str
@@ -250,7 +258,14 @@ class TrezorManager(object):
         resp = trezor_device.apply_settings(self._get_client(path).client, **kwargs)
         return 1 if resp == "Settings applied" else 0
 
-    def init(self, path="android_usb", label="BIXIN KEY", language="english", stronger_mnemonic=None, use_se=False):
+    def init(
+        self,
+        path: str = "android_usb",
+        label: str = "BIXIN KEY",
+        language: str = "english",
+        stronger_mnemonic: Optional[str] = None,
+        use_se: bool = False,
+    ) -> int:
         """
         Activate the device, used by hardware
         :param stronger_mnemonic: if not None 256  else 128
@@ -268,7 +283,7 @@ class TrezorManager(object):
         )
         return 1 if response == "Device successfully initialized" else 0
 
-    def reset_pin(self, path="android_usb") -> int:
+    def reset_pin(self, path: str = "android_usb") -> int:
         """
         Reset pin, used by hardware
         :param path:NFC/android_usb/bluetooth as str
@@ -286,7 +301,7 @@ class TrezorManager(object):
 
         return 1
 
-    def wipe_device(self, path="android_usb") -> int:
+    def wipe_device(self, path: str = "android_usb") -> int:
         """
         Reset device, used by hardware
         :param path: NFC/android_usb/bluetooth as str
@@ -304,11 +319,11 @@ class TrezorManager(object):
 
         return 1 if resp == "Device wiped" else 0
 
-    def get_passphrase_status(self, path="android_usb"):
+    def get_passphrase_status(self, path: str = "android_usb") -> bool:
         client = self._get_client(path=path)
         return client.features.passphrase_protection
 
-    def get_feature(self, path="android_usb"):
+    def get_feature(self, path: str = "android_usb") -> str:
         """
         Get hardware information, used by hardware
         :param path: NFC/android_usb/bluetooth as str
@@ -373,14 +388,14 @@ class TrezorManager(object):
 
     def firmware_update(
         self,
-        filename,
-        path,
-        type="",
-        fingerprint=None,
-        skip_check=True,
-        raw=False,
-        dry_run=False,
-    ):
+        filename: str,
+        path: str,
+        type: str = "",
+        fingerprint: Optional[str] = None,
+        skip_check: bool = True,
+        raw: bool = False,
+        dry_run: bool = False,
+    ) -> None:
         """
         Upload new firmware to device.used by hardware
         Note : Device must be in bootloader mode.

--- a/electrum_gui/android/hardware.py
+++ b/electrum_gui/android/hardware.py
@@ -10,7 +10,6 @@ from typing import Any, Optional
 from trezorlib import customer_ui as trezorlib_customer_ui
 from trezorlib import exceptions as trezor_exceptions
 from trezorlib import firmware as trezor_firmware
-from trezorlib import protobuf as trezor_protobuf
 from trezorlib.cli import trezorctl
 
 from electrum import plugin as electrum_plugin
@@ -357,7 +356,7 @@ class TrezorManager(object):
             self.plugin.clean()
             self.clients.pop(path, None)
             client = self._get_client(path=path)
-        return json.dumps(trezor_protobuf.to_dict(client.features))
+        return json.dumps(client.features_dict)
 
     def firmware_update(
         self,

--- a/electrum_gui/android/hardware.py
+++ b/electrum_gui/android/hardware.py
@@ -1,0 +1,440 @@
+import hashlib
+import json
+import time
+import threading
+from typing import Any, Optional
+
+# TODO: all these trezorlib imports should be moved into the lower level
+# trezorclient, perhaps except for the module trezor_exceptions. So that this
+# module only communicates with the trezor plugin, no lower level functions
+# would be directly called from this module.
+from trezorlib import customer_ui as trezorlib_customer_ui
+from trezorlib import device as trezor_device
+from trezorlib import exceptions as trezor_exceptions
+from trezorlib import firmware as trezor_firmware
+from trezorlib import messages as trezor_messages
+from trezorlib import protobuf as trezor_protobuf
+from trezorlib.cli import trezorctl
+
+from electrum import plugin as electrum_plugin
+from electrum.i18n import _
+from electrum.plugins.trezor import clientbase as trezor_clientbase
+from electrum_gui.android import firmware_sign_nordic_dfu
+
+TREZOR_PLUGIN_NAME = 'trezor'
+
+
+def _reboot_to_bootloader(client, dry_run=False):
+    if client.features.bootloader_mode:
+        return
+
+    resp = client.client.call(trezor_messages.BixinReboot())
+    if isinstance(resp, trezor_messages.Success) or dry_run:
+        time.sleep(2)
+        client.client.init_device()
+    else:
+        raise RuntimeError("Failed turn into bootloader")
+
+    if dry_run or client.features.bootloader_mode:
+        return
+
+    raise BaseException(_("Switch the device to bootloader mode."))
+
+
+def _do_firmware_update(client, data, type, dry_run=False):
+    if dry_run:
+        print("Dry run. Not uploading firmware to device.")
+        return
+
+    confirm_needed = client.features.major_version == 1 and client.features.firmware_present
+    if confirm_needed:
+        # Trezor One does not send ButtonRequest
+        print("Please confirm the action on your Trezor device")
+
+    try:
+        return trezor_firmware.update(client.client, data, type=type)
+    except trezor_exceptions.Cancelled:
+        print("Update aborted on device.")
+    except trezor_exceptions.TrezorException as e:
+        raise BaseException(_("Update failed: {}".format(e)))
+
+
+class TrezorManager(object):
+    """Interact with hardwares via electrum's trezor plugin."""
+
+    exposed_commands = (
+        'hardware_verify',
+        'backup_wallet',
+        'se_proxy',
+        'bixin_backup_device',
+        'bixin_load_device',
+        'recovery_wallet_hw',
+        'bx_inquire_whitelist',
+        'bx_add_or_delete_whitelist',
+        'apply_setting',
+        'init',
+        'reset_pin',
+        'wipe_device',
+        'get_passphrase_status',
+        'get_feature',
+        'firmware_update',
+    )
+
+    def __init__(self, plugin_manager: electrum_plugin.Plugins) -> None:
+        self.plugin = plugin_manager.get_plugin(TREZOR_PLUGIN_NAME)
+        # TODO: check whether multiple clients are really needed.
+        # With the latest commit(d68b538058d), only one client is allowed.
+        # However, it seems that the client can be overwritten and thus
+        # reinitialization of the client can happen many times.
+        # See d68b538058d/electrum/plugins/trezor/trezor.py#L188,L203
+        # To avoid redundant works, use a dict to store the needed clients.
+        self.clients = dict()
+        # NOTE: this lock is only used in get_feature(), should be removed
+        # when no longer needed.
+        self.lock = threading.RLock()
+
+    def _get_client(self, path: str) -> trezor_clientbase.TrezorClientBase:
+        # The meaning of 'path' is obsecure, it is used in the plugin to
+        # select a device.
+        # dict.setdefault() is not short-circuiting.
+        client = self.clients.get(path)
+        client = client or self.clients.setdefault(
+            path,
+            self.plugin.get_client(
+                path=path,
+                ui=trezorlib_customer_ui.CustomerUI()
+                # TODO: this ui parameter is not used and should be removed.
+            ),
+        )
+        return client
+
+    def _bridge(self, path: str, method: str, *args, **kwargs) -> Any:
+        # Bridge calls to the trezor client.
+        # TODO: this bridge method is only used for raising the BaseException
+        # because the caller might still expect a BaseException. Once we catch
+        # the excetpions in the upper call itself (and raise generic
+        # exceptions there), this should be removed.
+        try:
+            return getattr(self._get_client(path), method)(*args, **kwargs)
+        except Exception as e:
+            raise BaseException(e)
+
+    def _json_bridge(self, path: str, method: str, *args, **kwargs) -> Any:
+        return json.dumps(self._bridge(path, method, *args, **kwargs))
+
+    # === Begin helper methods used in console.AndroidCommands ===
+
+    def ensure_client(self, path: str) -> None:
+        self._get_client(path)
+
+    def get_device_id(self, path: str) -> str:
+        client = self._get_client(path)
+        return client.features.device_id
+
+    def get_xpub(self, path, derivation, _type, creating):
+        return self._bridge(path, 'get_xpub', derivation, _type, creating=creating)
+
+    def get_eth_xpub(self, path, derivation):
+        return self._bridge(path, 'get_eth_xpub', derivation)
+
+    # === End helper methods used in console.AndroidCommands ===
+
+    # Below are exposed methods, would be directly called from the upper users.
+
+    def hardware_verify(self, msg, path="android_usb") -> str:
+        """
+        Anti-counterfeiting verification, used by hardware
+        :param msg: msg as str
+        :param path: NFC/android_usb/bluetooth as str
+        :return: json like
+            {'serialno': 'Bixin20051500293',
+             'is_bixinkey': 'True',
+             'is_verified': 'True',
+             'last_check_time': 1611904981}
+        """
+        try:
+            digest = hashlib.sha256(msg.encode('utf-8')).digest()
+            # TODO: move this device.se_verify() call into trezor plugin's
+            # clientbase
+            response = trezor_device.se_verify(self._get_client(path).client, digest)
+        except Exception as e:
+            raise BaseException(e)
+        params = {"data": msg, "cert": response.cert.hex(), "signature": response.signature.hex()}
+        verify_url = "https://key.bixin.com/lengqian.bo/"
+        import requests
+
+        try:
+            res = requests.post(verify_url, data=params, timeout=30)
+        except Exception as e:
+            # TODO: check this translation is not needed and use
+            # RestfulRequest to do the whole verification job.
+            raise BaseException(_(str(e))) from e
+        else:
+            return res.text
+
+    def backup_wallet(self, path="android_usb"):
+        """
+        Backup wallet by se
+        :param path: NFC/android_usb/bluetooth as str, used by hardware
+        :return:
+        """
+        return self._bridge(path, 'backup')
+
+    def se_proxy(self, message, path="android_usb") -> str:
+        return self._bridge(path, 'se_proxy', message)
+
+    def bixin_backup_device(self, path="android_usb"):
+        """
+        Export seed, used by hardware
+        :param path: NFC/android_usb/bluetooth as str
+        :return: as string
+        """
+        return self._bridge(path, 'bixin_backup_device')
+
+    def bixin_load_device(self, path="android_usb", mnemonics=None, language="en-US", label="BIXIN KEY"):
+        """
+        Import seed, used by hardware
+        :param mnemonics: as string
+        :param path: NFC/android_usb/bluetooth as str
+        :return: raise except if error
+        """
+        return self._bridge(path, 'bixin_load_device', mnemonics=mnemonics, language=language, label=label)
+
+    def recovery_wallet_hw(self, path="android_usb", *args):
+        """
+        Recovery wallet by encryption
+        :param path: NFC/android_usb/bluetooth as str, used by hardware
+        :param args: encryption data as str
+        :return:
+        """
+        return self._bridge(path, 'recovery', *args)
+
+    def bx_inquire_whitelist(self, path="android_usb", **kwargs):
+        """
+        Inquire
+        :param path: NFC/android_usb/bluetooth as str, used by hardware
+        :param kwargs:
+            type:2=inquire
+            addr_in: addreess as str
+        :return:
+        """
+        return self._json_bridge(path, 'bx_inquire_whitelist', **kwargs)
+
+    def bx_add_or_delete_whitelist(self, path="android_usb", **kwargs):
+        """
+        Add and delete whitelist
+        :param path: NFC/android_usb/bluetooth as str, used by hardware
+        :param kwargs:
+            type:0=add 1=delete
+            addr_in: addreess as str
+        :return:
+        """
+        return self._json_bridge(path, 'bx_add_or_delete_whitelist', **kwargs)
+
+    def apply_setting(self, path="nfc", **kwargs):
+        """
+        Set the hardware function, used by hardware
+        :param path: NFC/android_usb/bluetooth as str
+        :param kwargs:
+            label="wangls"
+            language="chinese/english"
+            use_passphrase=true/false
+            auto_lock_delay_ms="600"
+            use_ble=true/false
+            use_se=true/false
+            is_bixinapp=true/false
+        :return:0/1
+        """
+        # TODO: move this device.apply_settings() call into trezor plugin's
+        # clientbase
+        resp = trezor_device.apply_settings(self._get_client(path).client, **kwargs)
+        return 1 if resp == "Settings applied" else 0
+
+    def init(self, path="android_usb", label="BIXIN KEY", language="english", stronger_mnemonic=None, use_se=False):
+        """
+        Activate the device, used by hardware
+        :param stronger_mnemonic: if not None 256  else 128
+        :param path: NFC/android_usb/bluetooth as str
+        :param label: name as string
+        :param language: as string
+        :param use_se: as bool
+        :return:0/1
+        """
+        if use_se:
+            self.apply_settings(path, use_se=True)
+        strength = 256 if stronger_mnemonic else 128
+        response = self._bridge(
+            path, 'reset_device', language=language, passphrase_protection=True, label=label, strength=strength
+        )
+        return 1 if response == "Device successfully initialized" else 0
+
+    def reset_pin(self, path="android_usb") -> int:
+        """
+        Reset pin, used by hardware
+        :param path:NFC/android_usb/bluetooth as str
+        :return:0/1
+        """
+        try:
+            # TODO: not using self._bridge() because we need to catch low-level
+            # exceptions.
+            client = self._get_client(path)
+            client.set_pin(False)
+        except (trezor_exceptions.PinException, RuntimeError):
+            return 0
+        except Exception:
+            raise BaseException("user cancel")
+
+        return 1
+
+    def wipe_device(self, path="android_usb") -> int:
+        """
+        Reset device, used by hardware
+        :param path: NFC/android_usb/bluetooth as str
+        :return:0/1
+        """
+        try:
+            # TODO: not using self._bridge() because we need to catch low-level
+            # exceptions.
+            client = self._get_client(path)
+            resp = client.wipe_device()
+        except (trezor_exceptions.PinException, RuntimeError):
+            return 0
+        except Exception as e:
+            raise BaseException(str(e)) from e
+
+        return 1 if resp == "Device wiped" else 0
+
+    def get_passphrase_status(self, path="android_usb"):
+        client = self._get_client(path=path)
+        return client.features.passphrase_protection
+
+    def get_feature(self, path="android_usb"):
+        """
+        Get hardware information, used by hardware
+        :param path: NFC/android_usb/bluetooth as str
+        :return: dict like:
+            {capabilities: List[EnumTypeCapability] = None,
+            vendor: str = None,
+            major_version: int = None,  主版本号
+            minor_version: int = None,  次版本号
+            patch_version: int = None
+                修订号，即硬件的软件版本(俗称固件，在2.0.1 之前使用)
+            bootloader_mode: bool = None,  设备当时是不是在bootloader模式
+            device_id: str = None,  设备唯一标识，设备恢复出厂设置这个值会变
+            pin_protection: bool = None, 是否开启了PIN码保护，
+            passphrase_protection: bool = None
+                是否开启了passphrase功能，这个用来支持创建隐藏钱包
+            language: str = None,
+            label: str = None,  激活钱包时，使用的名字
+            initialized: bool = None, 当时设备是否激活
+            revision: bytes = None,
+            bootloader_hash: bytes = None,
+            imported: bool = None,
+            unlocked: bool = None,
+            firmware_present: bool = None,
+            needs_backup: bool = None,
+            flags: int = None,
+            model: str = None,
+            fw_major: int = None,
+            fw_minor: int = None,
+            fw_patch: int = None,
+            fw_vendor: str = None,
+            fw_vendor_keys: bytes = None,
+            unfinished_backup: bool = None,
+            no_backup: bool = None,
+            recovery_mode: bool = None,
+            backup_type: EnumTypeBackupType = None,
+            sd_card_present: bool = None,
+            sd_protection: bool = None,
+            wipe_code_protection: bool = None,
+            session_id: bytes = None,
+            passphrase_always_on_device: bool = None,
+            safety_checks: EnumTypeSafetyCheckLevel = None,
+            auto_lock_delay_ms: int = None, 自动关机时间
+            display_rotation: int = None,
+            experimental_features: bool = None,
+            offset: int = None,  升级时断点续传使用的字段
+            ble_name: str = None,
+            ble_ver: str = None,  蓝牙固件版本
+            ble_enable: bool = None,
+            se_enable: bool = None,
+            se_ver: str = None,  se的版本
+            backup_only: bool = None
+                是否是特殊设备，只用来备份，没有额外功能支持
+            onekey_version: str = None
+                硬件的软件版本（俗称固件），仅供APP使用（从2.0.1开始加入）}
+        """
+        with self.lock:
+            # TODO: why is this lock needed
+            self.plugin.clean()
+            self.clients.pop(path, None)
+            client = self._get_client(path=path)
+        return json.dumps(trezor_protobuf.to_dict(client.features))
+
+    def firmware_update(
+        self,
+        filename,
+        path,
+        type="",
+        fingerprint=None,
+        skip_check=True,
+        raw=False,
+        dry_run=False,
+    ):
+        """
+        Upload new firmware to device.used by hardware
+        Note : Device must be in bootloader mode.
+        :param filename: full path to local upgrade file
+        :param path: NFC/android_usb/bluetooth as str
+        :return: None
+        """
+        if not filename:
+            raise BaseException(("Please give the file name"))
+
+        try:
+            if type:
+                data = firmware_sign_nordic_dfu.parse(filename)
+            else:
+                with open(filename, "rb") as datafile:
+                    data = datafile.read()
+        except Exception as e:
+            raise BaseException(e)
+
+        client = self._get_client(path)
+        _reboot_to_bootloader(client, dry_run=dry_run)
+
+        if raw:
+            return _do_firmware_update(client, data, type, dry_run=dry_run)
+
+        bootloader_onev2 = client.features.major_version == 1 and client.features.minor_version >= 8
+        embedded = bootloader_onev2 and data[:4] == b'TRZR' and data[256:260] == b'TRZF'
+        if embedded:
+            print("Extracting embedded firmware image " "(fingerprint may change).")
+            data = data[256:]
+
+        if skip_check:
+            return _do_firmware_update(client, data, type, dry_run=dry_run)
+
+        try:
+            version, fw = trezor_firmware.parse(data)
+        except Exception as e:
+            raise BaseException(e)
+
+        version_too_low = (
+            bootloader_onev2 and version == trezor_firmware.FirmwareFormat.TREZOR_ONE and not fw.embedded_onev2
+        )
+        need_upgrade = bootloader_onev2 and version == trezor_firmware.FirmwareFormat.TREZOR_ONE_V2
+
+        if version_too_low:
+            raise BaseException(_("Your device's firmware version is too low. Aborting."))
+        elif need_upgrade:
+            raise BaseException(_("You need to upgrade the bootloader immediately."))
+
+        compatible_versions = trezorctl.ALLOWED_FIRMWARE_FORMATS.get(client.features.major_version)
+        if compatible_versions is None:
+            raise BaseException(_("Trezorctl doesn't know your device version. Aborting."))
+        elif version not in compatible_versions:
+            raise BaseException(_("Firmware not compatible with your equipment, Aborting."))
+
+        trezorctl.validate_firmware(version, fw, fingerprint)
+        return _do_firmware_update(client, data, type, dry_run=dry_run)


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
拆分console.py中的硬件相关的部分
- 第一个commit是将console.py中硬件交互相关的内容拆分成独立文件，尽可能保持原样（包括潜在的错误）方便review
- 第二、五个commit是前一个文件改动到相关的文件就做代码风格的改动，标准是通过flake8
- 第三个commit为独立出来的硬件交互模块的方法加上annotation
- 第四、六、七个commit是将trezorlib的直接引用移动到trezor plugin中去，目标是将所有需要与trezor交互的内容都放到plugin中，将plugin作为lib使用，上层这个模块只关注业务相关的内容，接收app上层的请求，通过一个client访问底下的lib完成和硬件相关的工作。目前存在无业务代码只是直接转发请求到插件中的情况（且大多如此），原因是需要统一定义接口，以及上层命令调用没有做统一的异常处理/消息返回。一旦完成上层的异常处理/消息返回，也可以把单纯的转发删除掉，不过要看是否要保留函数定义从而通过docstring提供接口说明（后者较可能）。

## Does this close any currently open issues?  
No

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
N/A

## Any other comments?
No
