### PR TITLE
Console.py分拆 - 分离运行时钱包信息的缓存

### DIFF
--- a/electrum_gui/android/wallet_context.py
+++ b/electrum_gui/android/wallet_context.py
@@ -20,6 +20,8 @@ class WalletContext(object):
         self._type_info = self._init_type_info()
         self._save_type_info()
 
+        self._backup_info = self.config.get('backupinfo', {})
+
     @property
     def stored_wallets(self):
         return set(os.listdir(self.wallets_dir))
@@ -83,3 +85,22 @@ class WalletContext(object):
     def is_hw(self, address_digest: str) -> bool:
         wallet_type = self._type_info.get(address_digest, {}).get('type', '')
         return '-hw-' in wallet_type
+
+    def _save_backup_info(self) -> None:
+        self.config.set_key('backupinfo', self._backup_info)
+
+    def clear_backup_info(self) -> None:
+        self._backup_info = {}
+        self._save_backup_info()
+
+    def set_backup_info(self, xpub: str) -> None:
+        if xpub not in self._backup_info:
+            self._backup_info[xpub] = False
+            self._save_backup_info()
+
+    def get_backup_flag(self, xpub: str) -> bool:
+        return xpub not in self._backup_info
+
+    def remove_backup_info(self, xpub: str) -> None:
+        if self._backup_info.pop(xpub, None) is not None:
+            self._save_backup_info()

--- a/electrum_gui/android/wallet_context.py
+++ b/electrum_gui/android/wallet_context.py
@@ -9,6 +9,8 @@ from electrum_gui.android import derived_info
 
 class WalletContext(object):
     def __init__(self, config: simple_config.SimpleConfig, user_dir: str) -> None:
+        # NOTE: we use user config to store these infomation, should consider
+        # using database instead.
         self.config = config
 
         # TODO: This wallets_dir stuff should be moved into the storage submodule,
@@ -18,10 +20,27 @@ class WalletContext(object):
 
         # NOTE: The values of the following dict are of type dict. However only
         # the 'type' value in it is meaningful, therefore name it _type_info.
+        # Details of self._type_info:
+        #   Key: sha256 of the first address of the wallet, see
+        #        AndroidCommands.get_unique_path() in console.py
+        #   Value: a dict, explained below:
+        #          'type': a str indicating the wallet type
+        #          'time': a timestamp used only to sort items in
+        #                  self._type_info, see self.get_stored_wallets_types()
+        #          'xpubs': always [],  TODO: should be removed?
+        #          'seed': always '',  TODO: should be removed?
         self._type_info = self._init_type_info()
         self._save_type_info()
 
+        # Details of self._backup_info:
+        #   Key: a xpub (wallet.keystore.xpub)
+        #        or xpub + lowercase coin name (see
+        #        AndroidCommands.get_hd_wallet_encode_seed() in console.py)
+        #   Value: always False
         self._backup_info = self.config.get('backupinfo', {})
+        # Details of self._derived_info:
+        #   Key: a xpub or xpub + lowercase coin name, same as self._backup_info
+        #   Value: a dict with keys are 'name' and 'account_id'
         self._derived_info = self.config.get('derived_info', {})
 
     @property

--- a/electrum_gui/android/wallet_context.py
+++ b/electrum_gui/android/wallet_context.py
@@ -28,7 +28,6 @@ class WalletContext(object):
         #          'time': a timestamp used only to sort items in
         #                  self._type_info, see self.get_stored_wallets_types()
         #          'xpubs': always [],  TODO: should be removed?
-        #          'seed': always '',  TODO: should be removed?
         self._type_info = self._init_type_info()
         self._save_type_info()
 
@@ -59,7 +58,6 @@ class WalletContext(object):
                 info['time'] = time.time()
             if 'xpubs' not in info:
                 info['xpubs'] = []
-            info['seed'] = ''
             new_info[address_digest] = info
 
         return new_info
@@ -88,7 +86,7 @@ class WalletContext(object):
         return unknowns + saved
 
     def set_wallet_type(self, address_digest: str, wallet_type: str) -> None:
-        self._type_info[address_digest] = {'type': wallet_type, 'time': time.time(), 'seed': ''}
+        self._type_info[address_digest] = {'type': wallet_type, 'time': time.time()}
         self._save_type_info()
 
     def remove_type_info(self, address_digest: str) -> None:
@@ -96,8 +94,10 @@ class WalletContext(object):
             self._save_type_info()
 
     def is_hd(self, address_digest: str) -> bool:
+        # Essentially, this method equals a simple return of:
+        # return not self.is_hw(address_digest) and self.is_derived(address_digest)
         wallet_type = self._type_info.get(address_digest, {}).get('type', '')
-        return '-hw-' not in wallet_type and ('-hd-' in wallet_type or '-derived-' in wallet_type)
+        return '-hw-' not in wallet_type and '-derived-' in wallet_type
 
     def is_derived(self, address_digest: str) -> bool:
         wallet_type = self._type_info.get(address_digest, {}).get('type', '')

--- a/electrum_gui/android/wallet_context.py
+++ b/electrum_gui/android/wallet_context.py
@@ -1,0 +1,85 @@
+import itertools
+import os
+import time
+from typing import List, Tuple
+
+from electrum import simple_config, util
+
+
+class WalletContext(object):
+    def __init__(self, config: simple_config.SimpleConfig, user_dir: str) -> None:
+        self.config = config
+
+        # TODO: This wallets_dir stuff should be moved into the storage submodule,
+        # as well as the stored_wallets property below.
+        self.wallets_dir = util.standardize_path(os.path.join(user_dir, 'wallets'))
+        util.make_dir(self.wallets_dir)
+
+        # NOTE: The values of the following dict are of type dict. However only
+        # the 'type' value in it is meaningful, therefore name it _type_info.
+        self._type_info = self._init_type_info()
+        self._save_type_info()
+
+    @property
+    def stored_wallets(self):
+        return set(os.listdir(self.wallets_dir))
+
+    def _init_type_info(self) -> dict:
+        stored_wallets = self.stored_wallets
+        saved_info = self.config.get('all_wallet_type_info', {})
+        new_info = {}
+
+        for address_digest, info in saved_info.items():
+            if address_digest not in stored_wallets:
+                continue
+            if 'time' not in info:
+                info['time'] = time.time()
+            if 'xpubs' not in info:
+                info['xpubs'] = []
+            info['seed'] = ''
+            new_info[address_digest] = info
+
+        return new_info
+
+    def _save_type_info(self) -> None:
+        self.config.set_key('all_wallet_type_info', self._type_info)
+
+    def clear_type_info(self) -> None:
+        self._type_info = {}
+        self._save_type_info()
+
+    def get_stored_wallets_types(self) -> List[Tuple[str, str]]:
+        stored_wallets = self.stored_wallets
+
+        unknowns = list(zip(stored_wallets - set(self._type_info.keys()), itertools.repeat('unknow')))
+
+        saved_type_info = {
+            address_digest: type_info
+            for address_digest, type_info in self._type_info.items()
+            if address_digest in stored_wallets
+        }
+        saved = [
+            (kv[0], kv[1]['type']) for kv in sorted(saved_type_info.items(), key=lambda kv: kv[1]['time'], reverse=True)
+        ]
+
+        return unknowns + saved
+
+    def set_wallet_type(self, address_digest: str, wallet_type: str) -> None:
+        self._type_info[address_digest] = {'type': wallet_type, 'time': time.time(), 'seed': ''}
+        self._save_type_info()
+
+    def remove_type_info(self, address_digest: str) -> None:
+        if self._type_info.pop(address_digest, None) is not None:
+            self._save_type_info()
+
+    def is_hd(self, address_digest: str) -> bool:
+        wallet_type = self._type_info.get(address_digest, {}).get('type', '')
+        return '-hw-' not in wallet_type and ('-hd-' in wallet_type or '-derived-' in wallet_type)
+
+    def is_derived(self, address_digest: str) -> bool:
+        wallet_type = self._type_info.get(address_digest, {}).get('type', '')
+        return '-derived-' in wallet_type
+
+    def is_hw(self, address_digest: str) -> bool:
+        wallet_type = self._type_info.get(address_digest, {}).get('type', '')
+        return '-hw-' in wallet_type


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
分离出来console.py代码中原来的`local_wallet_info`、`backup_info`、`derived_info`。这些信息既可作为钱包属性，也可以另外存储但作为和钱包的关联属性存在（类比关系型数据库的关联表）。

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
N/A

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
N/A

## Any other comments?
@shuaiLiWang  第一个commit（分离local_wallet_info那个）里面几个关于检查类型的辅助方法需要额外关注。现在保持了原来的逻辑，但是原来的判断对什么时候需要判断是否硬件('-hw-')的要求不是很明确，要看看原来的判断是否已经有问题了。
