### PR TITLE
adjust get_provider_by_chain

### DIFF
--- a/electrum_gui/common/provider/exceptions.py
+++ b/electrum_gui/common/provider/exceptions.py
@@ -1,14 +1,14 @@
+from typing import Any
+
+
 class TransactionNotFound(Exception):
     def __init__(self, txid: str):
         super(TransactionNotFound, self).__init__(repr(txid))
         self.txid = txid
 
 
-class ProviderNotFound(Exception):
-    def __init__(self, chain_code: str):
-        super(ProviderNotFound, self).__init__(repr(chain_code))
-
-
-class ProvidersAllDown(Exception):
-    def __init__(self, chain_code: str, candidates: list):
-        super(ProvidersAllDown, self).__init__(f"{repr(chain_code)}, candidates: {candidates}")
+class NoAvailableProvider(Exception):
+    def __init__(self, chain_code: str, providers: list, instance_required: Any):
+        super(NoAvailableProvider, self).__init__(
+            f"chain_code: {repr(chain_code)}, providers: {providers}, instance_required: {instance_required}"
+        )


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
调整 get_provider_by_chain 的实现，支持获得特定类的实例。
目前 BlockBook，Etherscan 和 Geth 各有优劣，在使用过程中都可能要用到。
例如 ETH 在使用过程中会用默认的实例做获取价格，获取交易记录这种常规操作，
然后用 Geth 实例获取合约信息操作，还有通过 Etherscan 获取合约代码的信息

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
…

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
…

## Any other comments?
…
