### PR TITLE
Fix the problem that the balance of wallets created with the same mnemonic will be different

### DIFF
--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -353,6 +353,12 @@ class Abstract_Wallet(AddressSynchronizer, ABC):
         if self.storage and not self.hide_type:
             self.db.write(self.storage)
 
+    def set_key_pool_size(self):
+        if self.gap_limit != 100 and self.gap_limit_for_change != 100:
+            self.gap_limit = 100
+            self.gap_limit_for_change = 100
+            self.synchronize()
+
     def save_backup(self):
         backup_dir = get_backup_dir(self.config)
         if backup_dir is None:

--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -2939,6 +2939,8 @@ class AndroidCommands(commands.Commands):
                             coin,
                         )
                     self.wallet_context.set_wallet_type(wallet.identity, wallet_type)
+        for name, info in self.recovery_wallets.items():
+            info["wallet"].stop()
         self.recovery_wallets.clear()
 
     def delete_derived_wallet(self):
@@ -3722,7 +3724,6 @@ class AndroidCommands(commands.Commands):
 
         self.wallet = self.daemon.get_wallet(self._wallet_path(name))
         self.wallet.use_change = self.config.get("use_change", False)
-
         coin = self.wallet.coin
         if coin in self.coins:
             PyWalib.set_server(self.coins[coin])
@@ -3730,6 +3731,7 @@ class AndroidCommands(commands.Commands):
 
             info = {"name": name, "label": self.wallet.get_name(), "wallets": contract_info}
         else:
+            self.wallet.set_key_pool_size()
             c, u, x = self.wallet.get_balance()
             util.trigger_callback("wallet_updated", self.wallet)
 
@@ -3816,7 +3818,6 @@ class AndroidCommands(commands.Commands):
                 self.wallet = self.daemon.get_wallet(self._wallet_path(name))
 
             self.wallet.use_change = self.config.get("use_change", False)
-
             coin = self.wallet.coin
             if coin in self.coins:
                 PyWalib.set_server(self.coins[coin])


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
现象：相同的助记词导入不同的钱包 余额会不一致

原因：因为我们是fork的electrum 他会预先生成20的收款地址和10个找零地址 并且会维持这个未使用的地址个数（就是使用一个后会增加一个 这样就保证 我当前地址之后的20个地址的余额我都汇总在内了）。 我们现在的版本因为用户体验把这个20和10的限制修改成了1（因为创建钱包如果一下生成30个地址还是很耗时的，用户体验不是很好，而且恢复钱包的流程会更明显），这就导致了 如果用户使用过其他钱包 并且 其他钱包里边有间隔两个地址没有使用的情况 第三个地址的余额我们是统计不到的 所以 就有必要增加一个预先生成的地址池 这样就保证 统计到的余额是相对准确 但是 也不能保证一定准确 因为 如果用户自定义了一个间隔100+地址之后的地址 我们还是会统计不到 

为什么这么修改
1.没有在wallet.py中直接修改self.gap_limit值 是因为 创建钱包时候的速度要限制下来 所以选择在select_wallet的时候修改这个限制，去创建钱包
2.为什么要改成100 
   昨天改这里的时候 只是看bitcoin是默认的keypool是100 具体为什么要设置成100 后来他又提升到1000 这个我没找到相关的官方文档介绍 只是从字面意思自己判断的 觉得他是因为没有HD钱包的时候 一下会生成100个地址 还允许用户导出地址对应的私钥 这样就保证用户使用的地址都是备份过的 不至于出现钱丢失的现象  我们这个目前使用的都是HD钱包 不要提前生成那么多（这个有时间可以去跟踪具体原因）
   今天早上跟奥峰老师商量了一下 觉得我们这里只要维护20个的地址池就能保证大部分的情况了 没必要为了特别个例去维护100个或者1000个地址  所以 我会修改100为20

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
https://github.com/OneKeyHQ/TaskHub/issues/1001

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
python and App for android
## Any other comments?
…
