### PR TITLE
python开发环境快速启动

### DIFF
--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -190,7 +190,7 @@ class AndroidCommands(commands.Commands):
     _recovery_flag = True
 
     def __init__(self, android_id=None, config=None, user_dir=None, callback=None, chain_type="mainnet"):
-        self.asyncio_loop, self._stop_loop, self._loop_thread = create_and_start_event_loop()  # TODO:close loop
+        self.asyncio_loop, self._stop_loop, self._loop_thread = create_and_start_event_loop()
         self.config = config or simple_config.SimpleConfig({"auto_connect": True})
         if user_dir is None:
             self.user_dir = get_dir()
@@ -488,8 +488,12 @@ class AndroidCommands(commands.Commands):
         except Exception as e:
             raise BaseException(e)
         self.daemon.stop()
-        self.daemon.join()
         self.daemon_running = False
+        self.stop_loop()
+        self.plugin.stop()
+        global ticker
+        ticker.cancel()
+        the_begging.terminate()
 
     def set_hd_wallet(self, wallet_obj):
         if self.hd_wallet is None:

--- a/electrum_gui/common/basic/ticker/__init__.py
+++ b/electrum_gui/common/basic/ticker/__init__.py
@@ -15,3 +15,8 @@ def start_default_ticker(seconds: int):
 
     _ticker = ticker.Ticker(seconds, signals.ticker_signal)
     _ticker.start()
+
+
+def cancel_default_ticker():
+    global _ticker
+    _ticker.cancel()

--- a/electrum_gui/common/the_begging.py
+++ b/electrum_gui/common/the_begging.py
@@ -21,3 +21,9 @@ def initialize():
 
     # start ticker
     ticker.start_default_ticker(seconds=60)  # every 1 min
+
+
+def terminate():
+    from electrum_gui.common.basic import ticker
+
+    ticker.cancel_default_ticker()

--- a/start_debug_env.py
+++ b/start_debug_env.py
@@ -1,0 +1,63 @@
+import os
+
+import requests
+from trezorlib import customer_ui, transport
+from trezorlib.transport import bridge
+
+from electrum import constants
+from electrum_gui.android import console
+
+# Start monkey patches
+
+
+class _Handler(object):
+    @staticmethod
+    def sendEmptyMessage(code):
+        print(f"\nGot Custom UI empty message: {code}\n")
+
+
+customer_ui.CustomerUI.handler = _Handler()
+transport.all_transports = lambda: {bridge.BridgeTransport}
+
+# End monkey patches
+
+
+def list_connected_devices():
+    try:
+        requests.get(bridge.TREZORD_HOST)
+    except requests.ConnectionError:
+        print("Trezord not started, hardware debug would not be available...")
+    else:
+        devices = bridge.BridgeTransport.enumerate()
+        if devices:
+            print("Connected devices:\n    - ", end="", flush=True)
+            print("\n    -".join(str(device) for device in devices))
+        else:
+            print("No devices connected.")
+
+
+class FakeCallbackIntent(object):
+    def onCallback(self, *args, **kwargs):
+        print(f"callback invoked, args: {args}, kwargs: {kwargs}")
+
+
+_NETWORK_SET_FUNC = {
+    'sim': constants.set_simnet,
+    'test': constants.set_testnet,
+    'reg': constants.set_regtest,
+}
+
+
+# By default using main network
+set_network_func = _NETWORK_SET_FUNC.get(os.environ.get('USE_NETWORK'), None)
+if set_network_func is not None:
+    set_network_func()
+
+if 'AUTOSTART' in os.environ:
+    commands = console.AndroidCommands(os.environ['ANDROID_ID'], callback=FakeCallbackIntent())
+
+
+print("\n    *** Welcome ***\n")
+print("- Use list_connected_devices() to list connected hardwares.")
+if 'AUTOSTART' in os.environ:
+    print("- Type help(commands) to get the usage of commands.")

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-#envlist = py36, py37
-envlist = py36
+envlist = debug
 
 [testenv]
+basepython = python3.8
 deps=
 	pytest
 	coverage
@@ -11,3 +11,29 @@ commands=
 	coverage report
 extras=
 	tests
+
+[testenv:debug]
+skip_install = true
+passenv = HOME ELECTRUMDIR APPDATA LOCALAPPDATA AUTOSTART USE_NETWORK
+setenv =
+    ANDROID_ID = {env:ANDROID_ID:debug}
+deps =
+    aiohttp
+    aiohttp-socks
+    aiorpcX>=0.18,<0.19
+    bitstring
+    cryptography
+    dnspython
+    eth_utils
+    eth-account
+    ipython
+    libusb
+    mnemonic
+    peewee
+    protobuf
+    pyaes
+    requests
+    web3
+    git+https://github.com/OneKeyHQ/python-trezor.git
+commands =
+    ipython -i {toxinidir}/start_debug_env.py


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
使用tox+virtualenv快速启动一个python开发环境
- 放在virtualenv里和本地的python环境隔离模拟实际运行时的情况（我甚至想能不能装chaquopy）
- 洁癖患者福音，不干扰开发者本地的文件系统（所有相关内容都在.tox/debug里）
- 方便快速修改代码和进入调试环境
- 用monkey patch解决加载设备的问题（或者还有其他问题待遇到时处理），除了开发的代码，其它都不需要改动

#### 使用方法
1. 确保安装了tox（使用`pip3 install tox`）
2. 使用`tox -edebug`启动默认调试环境（不实例化`AndroidCommands`）
3. 使用`AUTOSTART="" tox -edebug`启动实例化`AndroidCommands`的调试环境，默认使用`"debug"`作为`android_id`字符串
4. 使用`ANDROID_ID`环境变量选择用于实例化`AndroidCommands`的`android_id`字符串
5. 使用`USE_NETWORK`环境变量选择使用的网络，默认主网，可选值为`"sim"/"test"/"reg"`
6. 例子如下（连接硬件之后`get_feature`和擦除设备）
```bash
$ AUTOSTART="" ANDROID_ID=myid tox -edebug
debug create: /Users/bixin/work/electrum/.tox/debug
debug installdeps: aiohttp, aiohttp-socks, aiorpcX, bitstring, cryptography, dnspython, eth_utils, eth-account, ipython, libusb, mnemonic, peewee, protobuf, pyaes, requests, web3, git+https://github.com/OneKeyHQ/python-trezor.git
debug installed: appdirs==1.4.4,bandit==1.7.0,black==20.8b1,cfgv==3.2.0,click==7.1.2,distlib==0.3.1,Electrum==4.0.2,filelock==3.0.12,flake8==3.9.0,gitdb==4.0.5,GitPython==3.1.14,identify==2.1.3,isort==5.7.0,mccabe==0.6.1,mypy-extensions==0.4.3,nodeenv==1.5.0,packaging==20.9,pathspec==0.8.1,pbr==5.5.1,pluggy==0.13.1,pre-commit==2.11.1,py==1.10.0,pycodestyle==2.7.0,pyflakes==2.3.0,pyparsing==2.4.7,PyYAML==5.4.1,regex==2021.3.17,six==1.15.0,smmap==3.0.5,stevedore==3.3.0,toml==0.10.2,tox==3.23.0,typed-ast==1.4.2,typing-extensions==3.7.4.3,virtualenv==20.4.3
debug run-test-pre: PYTHONHASHSEED='2191966600'
debug run-test: commands[0] | ipython -i /Users/bixin/work/electrum/start_debug_env.py
```
```
Python 3.8.2 (default, Dec 21 2020, 15:06:03) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.21.0 -- An enhanced Interactive Python. Type '?' for help.
W | ecc_fast | failed to load libsecp256k1: OSError('dlopen(libsecp256k1.0.dylib, 6): image not found')
/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/asyncio/base_events.py:1844: RuntimeWarning: coroutine 'ignore_exceptions.<locals>.wrapper' was never awaited
  handle = self._ready.popleft()
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
get symbol price error 'NoneType' object is not iterable
get symbol price error 'NoneType' object is not iterable
get symbol price error 'NoneType' object is not iterable
get symbol price error 'NoneType' object is not iterable
W | simple_config.SimpleConfig | not changing config key 'auto_connect' set on the command line
Exception in thread Thread-4:
Traceback (most recent call last):
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/bixin/work/electrum/electrum_gui/android/console.py", line 469, in daemon_action
    self.daemon.run_daemon()
  File "/Users/bixin/work/electrum/electrum/daemon.py", line 526, in run_daemon
    while self.is_running():
  File "/Users/bixin/work/electrum/electrum/daemon.py", line 534, in is_running
    return self.running and not self.taskgroup.closed()
AttributeError: 'TaskGroup' object has no attribute 'closed'
Start migrating...
Apply all migrations: coin, price
No migrations to apply.

    *** Welcome ***

- Use list_connected_devices() to list connected hardwares.
- Type help(commands) to get the usage of commands.

In [1]: list_connected_devices()
Connected devices:
    - bridge:4

In [2]: commands.get_feature("bridge:4")
begin session for===init_device===in===4381424960
receive response from >>>> bridge:4 : <Features: {'vendor': 'trezor.io', 'major_version': 1, 'minor_version': 9, 'patch_version': 8, 'device_id': '9E0CAAA6E6236A1638A567D4', 'pin_protection': False, 'passphrase_protection': False, 'language': 'zh-CN', 'initialized': False, 'revision': b'd\xd4\x9cw\x08?\x1d7\xca\xc5Y\x1f\t\x9a\x04|{\x81\xf4\x88', 'bootloader_hash': b'\xae\xdc/~\xb5\xbcj"I\xed5\xc3\x1f\x9d\x1e\x8dUW\xa3\x0e\xc6\xd66\xa6\xba\x9b>\x92\xc9mX)', 'unlocked': True, 'needs_backup': False, 'model': '1', 'unfinished_backup': False, 'no_backup': False, 'capabilities': [1, 2, 5, 7, 8, 10, 12, 14], 'wipe_code_protection': False, 'session_id': b'\xd4\xe0\xe5k\xcbD\r\xda(\xd9\x84\xcc\xbak\xfd \xecV\xa5\xd2\xb9\xb1i\x11\x7f\x04\xd7J\x8b&\x0e\xbe', 'auto_lock_delay_ms': 1800000, 'ble_name': 'K6355', 'ble_ver': '1.1.6', 'ble_enable': True, 'se_enable': False, 'se_ver': '2.0.0.2', 'backup_only': False, 'onekey_version': '2.0.4'}>
end session for init_device=====in=====4381424960
begin session for===apply_settings===in===4381424960
begin session for===call===in===4381424960
receive response from >>>> bridge:4 : <Success: {'message': 'Settings applied'}>
end session for call=====in=====4381424960
begin session for===refresh_features===in===4381424960
receive response from >>>> bridge:4 : <Features: {'vendor': 'trezor.io', 'major_version': 1, 'minor_version': 9, 'patch_version': 8, 'device_id': '9E0CAAA6E6236A1638A567D4', 'pin_protection': False, 'passphrase_protection': False, 'language': 'zh-CN', 'initialized': False, 'revision': b'd\xd4\x9cw\x08?\x1d7\xca\xc5Y\x1f\t\x9a\x04|{\x81\xf4\x88', 'bootloader_hash': b'\xae\xdc/~\xb5\xbcj"I\xed5\xc3\x1f\x9d\x1e\x8dUW\xa3\x0e\xc6\xd66\xa6\xba\x9b>\x92\xc9mX)', 'unlocked': True, 'needs_backup': False, 'model': '1', 'unfinished_backup': False, 'no_backup': False, 'capabilities': [1, 2, 5, 7, 8, 10, 12, 14], 'wipe_code_protection': False, 'auto_lock_delay_ms': 1800000, 'ble_name': 'K6355', 'ble_ver': '1.1.6', 'ble_enable': True, 'se_enable': False, 'se_ver': '2.0.0.2', 'backup_only': False, 'onekey_version': '2.0.4'}>
end session for refresh_features=====in=====4381424960
end session for apply_settings=====in=====4381424960
Out[2]: '{"vendor": "trezor.io", "major_version": 1, "minor_version": 9, "patch_version": 8, "device_id": "9E0CAAA6E6236A1638A567D4", "pin_protection": false, "passphrase_protection": false, "language": "zh-CN", "initialized": false, "revision": "64d49c77083f1d37cac5591f099a047c7b81f488", "bootloader_hash": "aedc2f7eb5bc6a2249ed35c31f9d1e8d5557a30ec6d636a6ba9b3e92c96d5829", "unlocked": true, "needs_backup": false, "model": "1", "unfinished_backup": false, "no_backup": false, "capabilities": ["Bitcoin", "Bitcoin_like", "Crypto", "Ethereum", "Lisk", "NEM", "Stellar", "U2F"], "wipe_code_protection": false, "auto_lock_delay_ms": 1800000, "ble_name": "K6355", "ble_ver": "1.1.6", "ble_enable": true, "se_enable": false, "se_ver": "2.0.0.2", "backup_only": false, "onekey_version": "2.0.4"}'

In [3]: commands.wipe_device("bridge:4")
begin session for===init_device===in===4381424960
receive response from >>>> bridge:4 : <Features: {'vendor': 'trezor.io', 'major_version': 1, 'minor_version': 9, 'patch_version': 8, 'device_id': '9E0CAAA6E6236A1638A567D4', 'pin_protection': False, 'passphrase_protection': False, 'language': 'zh-CN', 'initialized': False, 'revision': b'd\xd4\x9cw\x08?\x1d7\xca\xc5Y\x1f\t\x9a\x04|{\x81\xf4\x88', 'bootloader_hash': b'\xae\xdc/~\xb5\xbcj"I\xed5\xc3\x1f\x9d\x1e\x8dUW\xa3\x0e\xc6\xd66\xa6\xba\x9b>\x92\xc9mX)', 'unlocked': True, 'needs_backup': False, 'model': '1', 'unfinished_backup': False, 'no_backup': False, 'capabilities': [1, 2, 5, 7, 8, 10, 12, 14], 'wipe_code_protection': False, 'session_id': b'\xd4\xe0\xe5k\xcbD\r\xda(\xd9\x84\xcc\xbak\xfd \xecV\xa5\xd2\xb9\xb1i\x11\x7f\x04\xd7J\x8b&\x0e\xbe', 'auto_lock_delay_ms': 1800000, 'ble_name': 'K6355', 'ble_ver': '1.1.6', 'ble_enable': True, 'se_enable': False, 'se_ver': '2.0.0.2', 'backup_only': False, 'onekey_version': '2.0.4'}>
end session for init_device=====in=====4381424960
begin session for===wipe===in===4381424960
begin session for===call===in===4381424960
receive response from >>>> bridge:4 : <ButtonRequest: {'code': 6}>

Got Custom UI empty message: 106
receive response from >>>> bridge:4 : <Success: {'message': 'Device wiped'}>
end session for call=====in=====4381424960
begin session for===init_device===in===4381424960
receive response from >>>> bridge:4 : <Features: {'vendor': 'trezor.io', 'major_version': 1, 'minor_version': 9, 'patch_version': 8, 'device_id': '5FDA393EEB2750BC6063C891', 'pin_protection': False, 'passphrase_protection': False, 'language': 'zh-CN', 'initialized': False, 'revision': b'd\xd4\x9cw\x08?\x1d7\xca\xc5Y\x1f\t\x9a\x04|{\x81\xf4\x88', 'bootloader_hash': b'\xae\xdc/~\xb5\xbcj"I\xed5\xc3\x1f\x9d\x1e\x8dUW\xa3\x0e\xc6\xd66\xa6\xba\x9b>\x92\xc9mX)', 'unlocked': True, 'needs_backup': False, 'model': '1', 'unfinished_backup': False, 'no_backup': False, 'capabilities': [1, 2, 5, 7, 8, 10, 12, 14], 'wipe_code_protection': False, 'session_id': b'\xd4\xe0\xe5k\xcbD\r\xda(\xd9\x84\xcc\xbak\xfd \xecV\xa5\xd2\xb9\xb1i\x11\x7f\x04\xd7J\x8b&\x0e\xbe', 'auto_lock_delay_ms': 1800000, 'ble_name': 'K6355', 'ble_ver': '1.1.6', 'ble_enable': True, 'se_enable': False, 'se_ver': '2.0.0.2', 'backup_only': False, 'onekey_version': '2.0.4'}>
end session for init_device=====in=====4381424960
end session for wipe=====in=====4381424960
Out[3]: 1
```

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
No

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
- python 3.8.2 on MacBook Pro 2017 (BigSur 11.2.3, Intel Core i5)
- python 3.8.2 on MacBook Pro 2020 M1 (BigSur 11.2.3, Apple M1)

## Any other comments?
- 只在两台MacBook上测试过
- ~~tox没指定python版本，会用创建tox环境对应的那个python~~ 限制使用python3.8
- 依赖暂时只保证能运行起来，后续调试过程中欢迎继续添加
- ~~退出有问题，需要`Ctrl-C`~~ 补充第一个commit修复这个问题，退出前调用一次commands.stop()即可清理所有线程
- ipython不是人人都喜欢，有其他建议或者想用回原本的python repl请comment