### PR TITLE
Unify the switch wallet interface to return only the token address

### DIFF
--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -3711,8 +3711,8 @@ class AndroidCommands(commands.Commands):
             "name": "",
             "label": "",
             "wallets": [
-            {"coin": "eth", "address": ""},
-            {"coin": "usdt", "address": ""}
+            {"coin": "usdt", "address": ""},
+            ...
             ]
         }
         """
@@ -3736,7 +3736,7 @@ class AndroidCommands(commands.Commands):
             info = {
                 "name": name,
                 "label": self.wallet.get_name(),
-                "wallets": [{"coin": "btc", "address": ""}],
+                "wallets": [],
             }
             if self.label_flag and self.wallet.wallet_type != "standard":
                 self.label_plugin.load_wallet(self.wallet)


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
经跟ios和android讨论 统一switch_wallet接口返回的数据中wallets字段为token的信息

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
…

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
…

## Any other comments?
…
