### PR TITLE
[pref] reduced http requests during recovery process

### DIFF
--- a/electrum/pywalib.py
+++ b/electrum/pywalib.py
@@ -17,7 +17,7 @@ from eth_utils import add_0x_prefix, remove_0x_prefix
 from web3 import HTTPProvider, Web3
 
 from electrum.util import make_aiohttp_session
-from electrum_gui.common.provider.data import Token, TransactionStatus
+from electrum_gui.common.provider.data import Token, TransactionStatus, Address
 from electrum_gui.common.provider.interfaces import ProviderInterface
 from electrum_gui.common.provider.manager import get_provider_by_chain
 
@@ -601,6 +601,10 @@ class PyWalib:
             output_txs.append(output_tx)
 
         return output_txs
+
+    @classmethod
+    def get_address(cls, address) -> Address:
+        return cls.get_provider().get_address(address)
 
     @classmethod
     def get_all_txid(cls, address) -> List[str]:

--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -2952,17 +2952,10 @@ class AndroidCommands(commands.Commands):
                             address_info = None
 
                         if address_info and address_info.existing:
-                            balance_info = {
-                                coin: {
-                                    'address': '',
-                                    'balance': Decimal(self.pywalib.web3.fromWei(address_info.balance, "ether")),
-                                }
-                            }
-
-                            balance_info = self._fill_balance_info_with_fiat(wallet.coin, balance_info)
-                            balance_info = balance_info.get(coin)
-                            fiat_str = self.daemon.fx.ccy_amount_str(balance_info.get("fiat") or 0, True)
-                            balance = f"{balance_info.get('balance', '0')} ({fiat_str} {self.ccy})"
+                            main_coin_balance = Decimal(self.pywalib.web3.fromWei(address_info.balance, "ether"))
+                            fiat_price = price_manager.get_last_price(coin, self.ccy)
+                            fiat_str = self.daemon.fx.ccy_amount_str(main_coin_balance * fiat_price, True)
+                            balance = f"{main_coin_balance} ({fiat_str} {self.ccy})"
                             self.update_recover_list(recovery_list, balance, wallet, wallet.get_name(), coin)
                             continue
                 else:

--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -2947,14 +2947,17 @@ class AndroidCommands(commands.Commands):
                     with self.pywalib.override_server(self.coins[coin]):
                         address = wallet.get_addresses()[0]
                         try:
-                            txids = self.pywalib.get_all_txid(address)
+                            address_info = self.pywalib.get_address(address)
                         except Exception:
-                            txids = None
+                            address_info = None
 
-                        if txids:
-                            balance_info = wallet.get_all_balance(address, self.coins[coin]["symbol"])
-                            if not balance_info:
-                                continue
+                        if address_info and address_info.existing:
+                            balance_info = {
+                                coin: {
+                                    'address': '',
+                                    'balance': Decimal(self.pywalib.web3.fromWei(address_info.balance, "ether")),
+                                }
+                            }
 
                             balance_info = self._fill_balance_info_with_fiat(wallet.coin, balance_info)
                             balance_info = balance_info.get(coin)

--- a/electrum_gui/common/provider/clients/eth/blockbook.py
+++ b/electrum_gui/common/provider/clients/eth/blockbook.py
@@ -53,7 +53,7 @@ class BlockBook(ProviderInterface):
             address=address,
             balance=int(resp["balance"]),
             nonce=int(resp["nonce"]),
-            existing=True,
+            existing=bool(resp["txs"]),
         )
 
     def _get_raw_address_info(self, address: str, details: str, **kwargs) -> dict:

--- a/electrum_gui/common/provider/clients/eth/etherscan.py
+++ b/electrum_gui/common/provider/clients/eth/etherscan.py
@@ -52,7 +52,7 @@ class Etherscan(ProviderInterface):
 
         resp = self._call_action("proxy", "eth_getTransactionCount", address=address)
         nonce = int(resp["result"], base=16)
-        return Address(address=address, balance=balance, nonce=nonce)
+        return Address(address=address, balance=balance, nonce=nonce, existing=(bool(balance) or bool(nonce)))
 
     def get_balance(self, address: str, token: Token = None) -> int:
         if not token:

--- a/electrum_gui/common/provider/clients/eth/geth.py
+++ b/electrum_gui/common/provider/clients/eth/geth.py
@@ -41,13 +41,15 @@ class Geth(ProviderInterface):
         )
 
     def get_address(self, address: str) -> Address:
-        balance, nonce = self.rpc.batch_call(
+        _balance, _nonce = self.rpc.batch_call(
             [
                 ("eth_getBalance", [address, self.__LAST_BLOCK__]),
                 ("eth_getTransactionCount", [address, self.__LAST_BLOCK__]),
             ]
         )  # Maybe __LAST_BLOCK__ refers to a different blocks in some case
-        return Address(address=address, balance=_hex2int(balance), nonce=_hex2int(nonce))
+        balance = _hex2int(_balance)
+        nonce = _hex2int(_nonce)
+        return Address(address=address, balance=balance, nonce=nonce, existing=(bool(balance) or bool(nonce)))
 
     def get_balance(self, address: str, token: Token = None) -> int:
         if not token:

--- a/electrum_gui/common/provider/data.py
+++ b/electrum_gui/common/provider/data.py
@@ -82,7 +82,7 @@ class TxPaginate(DataClassMixin):
 class Address(DataClassMixin):
     address: str
     balance: int
-    existing: bool = True
+    existing: bool
     nonce: int = 0
     payload: dict = field(default_factory=dict)
 


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
filter_wallet 方法，会请求节点查询恢复地址的交易信息，和地址余额。
改动后使用 get_address 接口，来判断地址是否存在。

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
#https://github.com/OneKeyHQ/TaskHub/issues/802

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
python and App for android
### 以下分别是在 连接手机热点，和使用宽带网络情况下的，数据对比。
测试代码
```
for i in range(20):
    a = time()
    self.filter_wallet_before()
    a_time = time() - a
    b = time()
    self.filter_wallet()
    b_time = time() - b
    print("|", i+1, "|", a_time, "|", b_time, "|")
```


### IPhone 4G + Python + Mac + No Proxy
|  seq | before  | after  |
|---|---|---|
|1 | 11.016926050186157 | 9.206606149673462|
|2 | 10.029989004135132 | 9.575931072235107|
|3 | 10.155919075012207 | 8.379886865615845|
|4 | 9.439301013946533 | 8.257841110229492|
|5 | 11.142247200012207 | 9.520052909851074|
|6 | 9.949625730514526 | 9.098222255706787|
|7 | 10.417425155639648 | 7.899664878845215|
|8 | 10.387656927108765 | 22.86123490333557|
|9 | 11.414656162261963 | 22.299531936645508|
|10 | 10.082305908203125 | 8.14802885055542|
|11 | 8.249804019927979 | 8.133741617202759|
|12 | 10.37095594406128 | 8.695000648498535|
|13 | 11.018670082092285 | 9.061612129211426|
|14 | 9.926244735717773 | 8.802021980285645|
|15 | 11.540455102920532 | 9.853599071502686|
|16 | 9.142529010772705 | 9.686398983001709|
|17 | 9.438050031661987 | 9.423362016677856|
|18 | 11.510467767715454 | 8.729113101959229|
|19 | 9.480082988739014 | 12.67034912109375|
|20 | 9.906578779220581 | 8.417359113693237|

### WIFI + Python + Mac + No Proxy
|  seq | before  | after  |
|---|---|---|
| 1 | 36.221813917160034 | 25.260304927825928 |
| 2 | 26.840370893478394 | 12.831997156143188 |
| 3 | 13.46226191520691 | 10.020624876022339 |
| 4 | 11.293467044830322 | 10.021291732788086 |
| 5 | 13.596449613571167 | 9.812402248382568 |
| 6 | 10.821974992752075 | 9.5103280544281 |
| 7 | 14.317280054092407 | 9.724870920181274 |
| 8 | 13.95148491859436 | 10.191473007202148 |
| 9 | 14.599830150604248 | 9.581187725067139 |
| 10 | 10.723594188690186 | 10.761306762695312 |
| 11 | 12.777277946472168 | 43.52567768096924 |
| 12 | 12.951024293899536 | 10.257883787155151 |
| 13 | 12.608134984970093 | 10.267289876937866 |
| 14 | 10.706294059753418 | 10.607166051864624 |
| 15 | 11.512951850891113 | 9.34982705116272 |
| 16 | 15.511454820632935 | 10.917120933532715 |
| 17 | 15.062576055526733 | 26.30627202987671 |
| 18 | 27.480555057525635 | 22.282458066940308 |
| 19 | 27.453909158706665 | 14.434657096862793 |
| 20 | 11.592082738876343 | 8.808431148529053 |
## Any other comments?
在币种增多情况下，此页面需要处理的网络请求也会增加，从而增加耗时。

