### PR TITLE
Pre-compativility issue with loading old wallets due to incorrect android_id passing

### DIFF
--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -2004,6 +2004,15 @@ class Abstract_Wallet(AddressSynchronizer, ABC):
     def may_have_password(cls):
         return True
 
+    def force_change_storage_password(self, new_pw: Optional[str]):
+        """The password generation rules have changed to take care of the original password
+        and are not universal, this is only a temporary remedy and will be deprecated later"""
+        if self.storage and new_pw:
+            self.storage.set_password(new_pw, self.get_available_storage_encryption_version())
+        self.db.set_modified(True)
+        self.save_db()
+        self.storage_pw = new_pw
+
     def check_password(self, password, str_pw=None):
         if self.has_keystore_encryption():
             self.keystore.check_password(password)

--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -495,6 +495,7 @@ class AndroidCommands(commands.Commands):
             if self.wallet_context.is_hd(name):
                 self.set_hd_wallet(wallet)
             self.daemon.add_wallet(wallet)
+        return wallet
 
     def close_wallet(self, name=None):
         """Close a wallet"""
@@ -2828,7 +2829,12 @@ class AndroidCommands(commands.Commands):
         """
         name_wallets = sorted([name for name in os.listdir(self._wallet_path())])
         for name in name_wallets:
-            self.load_wallet(name, password=self.android_id)
+            try:
+                self.load_wallet(name, password=self.android_id)
+            except InvalidPassword:
+                storage_password = "112233%s" % self.android_id[-8:]
+                wallet = self.load_wallet(name, password=storage_password)
+                wallet.force_change_storage_password(self.android_id)
 
     def update_wallet_password(self, old_password, new_password):
         """

--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -3693,7 +3693,8 @@ class AndroidCommands(commands.Commands):
 
             info = {"name": name, "label": self.wallet.get_name(), "wallets": contract_info}
         else:
-            self.wallet.set_key_pool_size()
+            if not isinstance(self.wallet, Imported_Wallet):
+                self.wallet.set_key_pool_size()
             c, u, x = self.wallet.get_balance()
             util.trigger_callback("wallet_updated", self.wallet)
 


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
问题描述：
      之前android端传递给python的android_id为写死的值，正常情况下应该传递设备的唯一id给python。客户端如果现在直接更改这个值，这个版本之前的app创建的钱包就不能正确的被加载，此pr就是为了解决此问题

解决方法：
       用户传递正确的android_id，加载钱包时如果加载失败会尝试用之前错误的android_id进行加载



## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
…

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
Python

## Any other comments?
…
