### PR TITLE
Chainlist支持1 - 减少对pywalib的依赖

### DIFF
--- a/electrum/eth_wallet.py
+++ b/electrum/eth_wallet.py
@@ -215,9 +215,7 @@ class Abstract_Eth_Wallet(abc.ABC):
     #     self.save_db()
 
     def pubkeys_to_address(self, public_key: str):
-        return eth_utils.to_checksum_address(
-            eth_keys.utils.address.public_key_bytes_to_address(bytes.fromhex(public_key))
-        )
+        return eth_keys.keys.PublicKey(bytes.fromhex(public_key)).to_checksum_address()
 
     def set_total_balance(self, balance):
         self.total_balance['balance_info'] = balance
@@ -1233,9 +1231,7 @@ class Standard_Eth_Wallet(Simple_Eth_Deterministic_Wallet):
         self.hd_main_eth_address = ''
 
     def pubkeys_to_address(self, public_key: str):
-        return eth_utils.to_checksum_address(
-            eth_keys.utils.address.public_key_bytes_to_address(bytes.fromhex(public_key))
-        )
+        return eth_keys.keys.PublicKey(bytes.fromhex(public_key)).to_checksum_address()
 
     def get_keystore_by_address(self, address, password):
         privatekey = self.get_private_key(address, password)

--- a/electrum/eth_wallet.py
+++ b/electrum/eth_wallet.py
@@ -270,14 +270,14 @@ class Abstract_Eth_Wallet(abc.ABC):
         if not contract_address:
             return None
 
-        contract_address = pywalib.PyWalib.web3.toChecksumAddress(contract_address)
+        contract_address = eth_utils.to_checksum_address(contract_address)
         return self.contacts.get(contract_address)
 
     def delete_contract_token(self, contract_address):
         if not contract_address:
             return
 
-        contract_address = pywalib.PyWalib.web3.toChecksumAddress(contract_address)
+        contract_address = eth_utils.to_checksum_address(contract_address)
         self.contacts.pop(contract_address, None)
         self.db.put("contracts", {addr: c.symbol for addr, c in self.contacts.items()})
         self.save_db()
@@ -706,7 +706,7 @@ class Abstract_Eth_Wallet(abc.ABC):
             preamble = f"\x19Ethereum Signed Message:\n{len(message_bytes)}"
             message_bytes = preamble.encode() + message_bytes
 
-        message_hash = pywalib.PyWalib.web3.keccak(message_bytes)
+        message_hash = eth_utils.keccak(message_bytes)
 
         if isinstance(self.keystore, keystore.Hardware_KeyStore):
             index = self.get_address_index(address)
@@ -947,7 +947,7 @@ class Imported_Eth_Wallet(Simple_Eth_Wallet):
         good_addr = []  # type: List[str]
         bad_addr = []  # type: List[Tuple[str, str]]
         for address in addresses:
-            if not address or not pywalib.PyWalib.get_web3().isAddress(address):
+            if not address or not eth_utils.is_address(address):
                 bad_addr.append((address, i18n._('invalid address')))
                 continue
 
@@ -994,7 +994,7 @@ class Imported_Eth_Wallet(Simple_Eth_Wallet):
             except BaseException as e:
                 bad_keys.append((key, i18n._('invalid private key') + f': {e}'))
                 continue
-            addr = pywalib.PyWalib.web3.toChecksumAddress(pubkey.to_address())
+            addr = eth_utils.to_checksum_address(pubkey.to_address())
             good_addr.append(addr)
             self.db.add_imported_address(addr, {'pubkey': pubkey.__str__()})
             # self.add_address(addr)

--- a/electrum/plugins/hw_wallet/plugin.py
+++ b/electrum/plugins/hw_wallet/plugin.py
@@ -36,6 +36,8 @@ from electrum.bip32 import BIP32Node
 from electrum.storage import get_derivation_used_for_hw_device_encryption
 from electrum.keystore import Xpub, Hardware_KeyStore
 
+import eth_utils
+
 if TYPE_CHECKING:
     import threading
     from electrum.wallet import Abstract_Wallet
@@ -121,8 +123,7 @@ class HW_PluginBase(BasePlugin):
     def show_address_helper(self, wallet, address, keystore=None):
         if keystore is None:
             keystore = wallet.get_keystore()
-        from electrum.pywalib import PyWalib
-        if not is_address(address) and not PyWalib.web3.isAddress(address):
+        if not is_address(address) and not eth_utils.is_address(address):
             keystore.handler.show_error(_('Invalid Bitcoin Address or Invalid Ethernum Address'))
             return False
         if not wallet.is_mine(address):

--- a/electrum/util.py
+++ b/electrum/util.py
@@ -55,6 +55,7 @@ from aiorpcx import TaskGroup
 import certifi
 import dns.resolver
 import ecdsa
+import eth_utils
 
 from .i18n import _
 from .logging import get_logger, Logger
@@ -970,7 +971,6 @@ class InvalidAddressURI(Exception):
 def parse_URI(uri: str, on_pr: Callable = None, *, loop=None) -> dict:
     """Raises InvalidBitcoinURI on malformed URI."""
     from . import bitcoin
-    from .pywalib import PyWalib
 
     if not isinstance(uri, str):
         raise InvalidAddressURI(f"expected string, not {repr(uri)}")
@@ -991,7 +991,7 @@ def parse_URI(uri: str, on_pr: Callable = None, *, loop=None) -> dict:
 
     if bitcoin.is_address(address):
         res["coin"] = "btc"
-    elif PyWalib.web3.isAddress(address):
+    elif eth_utils.is_address(address):
         coin = u.scheme if u.scheme in ("eth", "bsc", "heco") else "eth"
         res["coin"] = coin
 

--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -316,7 +316,7 @@ class AndroidCommands(commands.Commands):
         out = dict()
 
         if coin in self.coins:  # eth base
-            address = self.pywalib.web3.toChecksumAddress(address)
+            address = eth_utils.to_checksum_address(address)
             balance_info = self.wallet.get_all_balance(address, self.coins[coin]["symbol"])
             balance_info = self._fill_balance_info_with_fiat(self.wallet.coin, balance_info)
             sum_fiat = sum(i.get("fiat", 0) for i in balance_info.values())
@@ -1780,7 +1780,7 @@ class AndroidCommands(commands.Commands):
 
             if bitcoin.is_address(self.show_addr):
                 data = util.create_bip21_uri(self.show_addr, "", "")
-            elif self.pywalib.web3.isAddress(self.show_addr):
+            elif eth_utils.is_address(self.show_addr):
                 prefix = "ethereum" if self.wallet.coin == "eth" else self.wallet.coin
                 data = f"{prefix}:{self.show_addr}"
             else:
@@ -2101,7 +2101,7 @@ class AndroidCommands(commands.Commands):
         message = message.strip()
         coin = self.wallet.coin
         if coin in self.coins:
-            if not self.pywalib.web3.isAddress(address):
+            if not eth_utils.is_address(address):
                 raise UnavailableEthAddr()
         elif coin == 'btc':
             if not bitcoin.is_address(address):
@@ -2134,7 +2134,7 @@ class AndroidCommands(commands.Commands):
             if not bitcoin.is_address(address):
                 raise UnavailableBtcAddr()
         elif coin in self.coins:
-            if not self.pywalib.web3.isAddress(address):
+            if not eth_utils.is_address(address):
                 raise UnavailableEthAddr()
         else:
             raise UnsupportedCurrencyCoin()
@@ -2262,7 +2262,7 @@ class AndroidCommands(commands.Commands):
                 token_info.get("logoURI"),
             )
 
-            contract_addr = self.pywalib.web3.toChecksumAddress(contract_addr)
+            contract_addr = eth_utils.to_checksum_address(contract_addr)
             self.wallet.add_contract_token(symbol, contract_addr)
 
     def delete_token(self, contract_addr):
@@ -2308,7 +2308,7 @@ class AndroidCommands(commands.Commands):
                 from_address, to_addr, value, gas_price=gas_price, gas_limit=gas_limit, data=data, nonce=nonce
             )
         else:
-            contract_addr = self.pywalib.web3.toChecksumAddress(contract_addr)
+            contract_addr = eth_utils.to_checksum_address(contract_addr)
             contract = self.wallet.get_contract_token(contract_addr)
             assert contract is not None
             tx_dict = self.pywalib.get_transaction(
@@ -2826,7 +2826,7 @@ class AndroidCommands(commands.Commands):
                 except BaseException:
                     raise BaseException(UnavailablePublicKey())
             elif flag == "address":
-                if not self.pywalib.web3.isAddress(data):
+                if not eth_utils.is_address(data):
                     raise UnavailableEthAddr()
 
     def replace_watch_only_wallet(self, replace=True):
@@ -3583,7 +3583,7 @@ class AndroidCommands(commands.Commands):
                 coin = wallet.coin
                 if coin in self.coins:
                     with self.pywalib.override_server(self.coins[coin]):
-                        checksum_from_address = self.pywalib.web3.toChecksumAddress(wallet.get_addresses()[0])
+                        checksum_from_address = eth_utils.to_checksum_address(wallet.get_addresses()[0])
                         balances_info = wallet.get_all_balance(checksum_from_address, self.coins[coin]["symbol"])
                         balances_info = self._fill_balance_info_with_fiat(wallet.coin, balances_info)
                         sorted_balances = [balances_info.pop(coin, {})]
@@ -3986,7 +3986,7 @@ class AndroidCommands(commands.Commands):
         coin = self.wallet.coin
         if coin in self.coins:
             addrs = self.wallet.get_addresses()
-            checksum_from_address = self.pywalib.web3.toChecksumAddress(addrs[0])
+            checksum_from_address = eth_utils.to_checksum_address(addrs[0])
             balance_info = self.wallet.get_all_balance(checksum_from_address, self.coins[coin]["symbol"])
             balance_info = self._fill_balance_info_with_fiat(self.wallet.coin, balance_info)
             sum_fiat = sum(i.get("fiat", 0) for i in balance_info.values())
@@ -4057,7 +4057,7 @@ class AndroidCommands(commands.Commands):
             if coin in self.coins:
                 PyWalib.set_server(self.coins[coin])
                 addrs = self.wallet.get_addresses()
-                checksum_from_address = self.pywalib.web3.toChecksumAddress(addrs[0])
+                checksum_from_address = eth_utils.to_checksum_address(addrs[0])
                 balance_info = self.wallet.get_all_balance(checksum_from_address, self.coins[coin]["symbol"])
                 balance_info = self._fill_balance_info_with_fiat(self.wallet.coin, balance_info)
                 sorted_balances = [balance_info.pop(coin, {})]


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

减少对pywalib的依赖，去掉多余的wrap

- 整理eth_wallet.py，这个文件是我们添加的非electrum项目原生的内容，所以整体代码风格可以调整方便之后进一步做迁移。（包括flake8，black，isort，根据google python code style完成imports的调整）
- 简化eth_wallet中的两个调用
- 清理掉通过pywalib/web3的wrap，可以直接使用底层的eth_keys和eth_utils（web3默认需要提供一个http endpoint了，但新增在electrum_gui/common下的逻辑完成了RPC的工作）

## Does this close any currently open issues?  
OneKeyHQ/TaskHub#1181 的一部分工作

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
N/A

## Any other comments?
无
