### PR TITLE
Extract SearchTransactionMixin

### DIFF
--- a/electrum_gui/common/coin/configs/chains.json
+++ b/electrum_gui/common/coin/configs/chains.json
@@ -32,6 +32,10 @@
     ],
     "clients": [
       {
+        "class": "Geth",
+        "url": "https://mainnet.infura.io/v3/f001ce716b6e4a33a557f74df6fe8eff"
+      },
+      {
         "class": "BlockBook",
         "url": "https://eth1.onekey.so"
       },
@@ -52,10 +56,6 @@
         "api_keys": [
           "R796P9T31MEA24P8FNDZBCA88UHW8YCNVW"
         ]
-      },
-      {
-        "class": "Geth",
-        "url": "https://mainnet.infura.io/v3/f001ce716b6e4a33a557f74df6fe8eff"
       }
     ],
     "chain_affinity": "eth",
@@ -78,12 +78,12 @@
     ],
     "clients": [
       {
-        "class": "BlockBook",
-        "url": "https://bsc1.onekey.so"
-      },
-      {
         "class": "Geth",
         "url": "https://bsc-dataseed1.binance.org"
+      },
+      {
+        "class": "BlockBook",
+        "url": "https://bsc1.onekey.so"
       }
     ],
     "chain_affinity": "eth",
@@ -106,12 +106,12 @@
     ],
     "clients": [
       {
-        "class": "BlockBook",
-        "url": "https://heco1.onekey.so"
-      },
-      {
         "class": "Geth",
         "url": "https://http-mainnet-node.huobichain.com"
+      },
+      {
+        "class": "BlockBook",
+        "url": "https://heco1.onekey.so"
       }
     ],
     "chain_affinity": "eth",

--- a/electrum_gui/common/coin/configs/chains.json
+++ b/electrum_gui/common/coin/configs/chains.json
@@ -33,7 +33,7 @@
     "clients": [
       {
         "class": "Geth",
-        "url": "https://mainnet.infura.io/v3/f001ce716b6e4a33a557f74df6fe8eff"
+        "url": "https://eth1.onekey.so/rpc"
       },
       {
         "class": "BlockBook",
@@ -79,7 +79,7 @@
     "clients": [
       {
         "class": "Geth",
-        "url": "https://bsc-dataseed1.binance.org"
+        "url": "https://bsc1.onekey.so/rpc"
       },
       {
         "class": "BlockBook",
@@ -107,7 +107,7 @@
     "clients": [
       {
         "class": "Geth",
-        "url": "https://http-mainnet-node.huobichain.com"
+        "url": "https://heco1.onekey.so/rpc"
       },
       {
         "class": "BlockBook",

--- a/electrum_gui/common/coin/configs/testnet_chains.json
+++ b/electrum_gui/common/coin/configs/testnet_chains.json
@@ -32,6 +32,10 @@
     ],
     "clients": [
       {
+        "class": "Geth",
+        "url": "https://ropsten.infura.io/v3/f001ce716b6e4a33a557f74df6fe8eff"
+      },
+      {
         "class": "BlockBook",
         "url": "https://ropsten1.trezor.io"
       },
@@ -41,10 +45,6 @@
         "api_keys": [
           "R796P9T31MEA24P8FNDZBCA88UHW8YCNVW"
         ]
-      },
-      {
-        "class": "Geth",
-        "url": "https://ropsten.infura.io/v3/f001ce716b6e4a33a557f74df6fe8eff"
       }
     ],
     "chain_affinity": "eth",

--- a/electrum_gui/common/provider/chains/eth/clients/blockbook.py
+++ b/electrum_gui/common/provider/chains/eth/clients/blockbook.py
@@ -23,10 +23,10 @@ from electrum_gui.common.provider.data import (
     TxPaginate,
 )
 from electrum_gui.common.provider.exceptions import TransactionNotFound
-from electrum_gui.common.provider.interfaces import ClientInterface
+from electrum_gui.common.provider.interfaces import ClientInterface, SearchTransactionMixin
 
 
-class BlockBook(ClientInterface):
+class BlockBook(ClientInterface, SearchTransactionMixin):
     __raw_tx_status_mapping__ = {
         -1: TransactionStatus.PENDING,
         0: TransactionStatus.CONFIRM_REVERTED,

--- a/electrum_gui/common/provider/chains/eth/clients/etherscan.py
+++ b/electrum_gui/common/provider/chains/eth/clients/etherscan.py
@@ -18,10 +18,10 @@ from electrum_gui.common.provider.data import (
     TxBroadcastReceiptCode,
     TxPaginate,
 )
-from electrum_gui.common.provider.interfaces import ClientInterface
+from electrum_gui.common.provider.interfaces import ClientInterface, SearchTransactionMixin
 
 
-class Etherscan(ClientInterface):
+class Etherscan(ClientInterface, SearchTransactionMixin):
     def __init__(self, url: str, api_keys: List[str] = None):
         self.restful = RestfulRequest(url)
         self.api_key = api_keys[0] if api_keys else None

--- a/electrum_gui/common/provider/chains/eth/clients/geth.py
+++ b/electrum_gui/common/provider/chains/eth/clients/geth.py
@@ -61,7 +61,7 @@ class Geth(ClientInterface):
             resp = self.eth_call({"to": token.contract, "data": call_balance_of})
 
             try:
-                return _hex2int(resp)
+                return _hex2int(resp[:66])
             except ValueError:
                 return 0
 

--- a/electrum_gui/common/provider/interfaces.py
+++ b/electrum_gui/common/provider/interfaces.py
@@ -69,7 +69,24 @@ class ClientInterface(ABC):
         except TransactionNotFound:
             return TransactionStatus.UNKNOWN
 
-    def search_txs_by_address(
+    @abstractmethod
+    def broadcast_transaction(self, raw_tx: str) -> TxBroadcastReceipt:
+        """
+        push transaction to chain
+        :param raw_tx: transaction in str
+        :return: txid, optional
+        """
+
+    @abstractmethod
+    def get_price_per_unit_of_fee(self) -> PricePerUnit:
+        """
+        get the price per unit of the fee, likes the gas_price on eth
+        :return: price per unit
+        """
+
+
+class SearchTransactionMixin(ABC):
+    def search_txs_by_address(  # noqa
         self,
         address: str,
         paginate: Optional[TxPaginate] = None,
@@ -98,21 +115,6 @@ class ClientInterface(ABC):
         txids = {i.txid for i in txs}
         txids = list(txids)
         return txids
-
-    @abstractmethod
-    def broadcast_transaction(self, raw_tx: str) -> TxBroadcastReceipt:
-        """
-        push transaction to chain
-        :param raw_tx: transaction in str
-        :return: txid, optional
-        """
-
-    @abstractmethod
-    def get_price_per_unit_of_fee(self) -> PricePerUnit:
-        """
-        get the price per unit of the fee, likes the gas_price on eth
-        :return: price per unit
-        """
 
 
 class ProviderInterface(ABC):

--- a/electrum_gui/common/provider/loader.py
+++ b/electrum_gui/common/provider/loader.py
@@ -85,7 +85,7 @@ def get_client_by_chain(
         try:
             is_ready, skip_seconds = client.is_ready, 300
         except Exception as e:
-            is_ready, skip_seconds = False, 180
+            is_ready, skip_seconds = False, 30
             logger.info(f"Error in check status of <{candidate}>. error: {e}", exc_info=True)
 
         candidate.update({"expired_at": int(time.time() + skip_seconds), "is_ready": is_ready})

--- a/electrum_gui/common/provider/loader.py
+++ b/electrum_gui/common/provider/loader.py
@@ -57,7 +57,7 @@ def get_client_by_chain(
     chain_code: str,
     force_update: bool = False,
     instance_required: Any = None,
-) -> ClientInterface:
+) -> Any:
     candidates = _CANDIDATE_CLIENTS_CACHE.get(chain_code)
 
     if not candidates:

--- a/electrum_gui/common/provider/manager.py
+++ b/electrum_gui/common/provider/manager.py
@@ -10,6 +10,8 @@ from electrum_gui.common.provider.data import (
     TxBroadcastReceipt,
     TxPaginate,
 )
+from electrum_gui.common.provider.exceptions import NoAvailableClient
+from electrum_gui.common.provider.interfaces import SearchTransactionMixin
 from electrum_gui.common.provider.loader import get_client_by_chain, get_provider_by_chain
 
 
@@ -34,7 +36,12 @@ def search_txs_by_address(
     address: str,
     paginate: Optional[TxPaginate] = None,
 ) -> List[Transaction]:
-    return get_client_by_chain(chain_code).search_txs_by_address(address, paginate=paginate)
+    try:
+        return get_client_by_chain(chain_code, instance_required=SearchTransactionMixin).search_txs_by_address(
+            address, paginate=paginate
+        )
+    except NoAvailableClient:
+        return []
 
 
 def search_txids_by_address(
@@ -42,7 +49,12 @@ def search_txids_by_address(
     address: str,
     paginate: Optional[TxPaginate] = None,
 ) -> List[str]:
-    return get_client_by_chain(chain_code).search_txids_by_address(address, paginate=paginate)
+    try:
+        return get_client_by_chain(chain_code, instance_required=SearchTransactionMixin).search_txids_by_address(
+            address, paginate=paginate
+        )
+    except NoAvailableClient:
+        return []
 
 
 def broadcast_transaction(chain_code: str, raw_tx: str) -> TxBroadcastReceipt:


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
1. 从 ClientInterface 中提取出 SearchTransactionMixin，eth 相关的请求优先走 Geth，交易历史相关的才走 trezor blockbook
2. 修复 geth 获取 erc20 余额，不知是不是 bsc 改了节点的原因还是其他的，返回的数据跟 eth 有些不同，在某些情况下末尾多了一个32字节格式的 0 （可能这也是导致 trezor blockbook 无法获取某些代币余额的原因）
3. 将 Geth rpc 换成咱自己 trezor blockbook 暴露的 rpc

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
…

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
…

## Any other comments?
…
