### PR TITLE
Filling ProviderInterface

### DIFF
--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -1934,7 +1934,7 @@ class AndroidCommands(commands.Commands):
                         {
                             "coin": _remove_testnet_prefix(chain.chain_code),
                             "prefix": chain.qr_code_prefix,
-                            "format": validation.format,
+                            "encoding": validation.encoding,
                         }
                     )
             except Exception as e:

--- a/electrum_gui/common/provider/chains/btc/provider.py
+++ b/electrum_gui/common/provider/chains/btc/provider.py
@@ -1,6 +1,9 @@
+from typing import Dict
+
 from electrum import bitcoin
-from electrum_gui.common.provider.data import AddressValidation
+from electrum_gui.common.provider.data import AddressValidation, SignedTx, UnsignedTx
 from electrum_gui.common.provider.interfaces import ProviderInterface
+from electrum_gui.common.secret.interfaces import SignerInterface, VerifierInterface
 
 
 class BTCProvider(ProviderInterface):
@@ -13,3 +16,12 @@ class BTCProvider(ProviderInterface):
             is_valid, encoding = True, "b58"
 
         return AddressValidation(is_valid=is_valid, encoding=encoding)
+
+    def pubkey_to_address(self, verifier: VerifierInterface, encoding: str = None) -> str:
+        raise NotImplementedError()
+
+    def filling_unsigned_tx(self, unsigned_tx: UnsignedTx) -> UnsignedTx:
+        raise NotImplementedError()
+
+    def sign_transaction(self, unsigned_tx: UnsignedTx, key_mapping: Dict[str, SignerInterface]) -> SignedTx:
+        raise NotImplementedError()

--- a/electrum_gui/common/provider/chains/btc/provider.py
+++ b/electrum_gui/common/provider/chains/btc/provider.py
@@ -5,11 +5,11 @@ from electrum_gui.common.provider.interfaces import ProviderInterface
 
 class BTCProvider(ProviderInterface):
     def verify_address(self, address: str) -> AddressValidation:
-        is_valid, address_format = False, None
+        is_valid, encoding = False, None
 
         if bitcoin.is_segwit_address(address):
-            is_valid, address_format = True, "segwit"
+            is_valid, encoding = True, "segwit"
         elif bitcoin.is_b58_address(address):
-            is_valid, address_format = True, "b58"
+            is_valid, encoding = True, "b58"
 
-        return AddressValidation(is_valid, address_format)
+        return AddressValidation(is_valid=is_valid, encoding=encoding)

--- a/electrum_gui/common/provider/chains/eth/clients/geth.py
+++ b/electrum_gui/common/provider/chains/eth/clients/geth.py
@@ -1,6 +1,8 @@
 from functools import partial
 from typing import Any
 
+import eth_utils
+
 from electrum_gui.common.basic.functional.require import require
 from electrum_gui.common.basic.request.exceptions import JsonRPCException
 from electrum_gui.common.basic.request.json_rpc import JsonRPCRequest
@@ -146,3 +148,17 @@ class Geth(ClientInterface):
             normal=EstimatedTimeOnPrice(price=normal, time=180),
             slow=EstimatedTimeOnPrice(price=slow, time=600),
         )
+
+    def estimate_gas_limit(self, from_address: str, to_address: str, value: int, data: str = None) -> int:
+        resp = self.rpc.call(
+            "eth_estimateGas",
+            params=[{"from": from_address, "to": to_address, "value": hex(value), "data": data or "0x"}],
+        )
+        return _hex2int(resp)
+
+    def get_contract_code(self, address: str) -> str:
+        resp = self.rpc.call("eth_getCode", params=[address, self.__LAST_BLOCK__])
+        return eth_utils.remove_0x_prefix(resp)
+
+    def is_contract(self, address: str) -> bool:
+        return len(self.get_contract_code(address)) > 0

--- a/electrum_gui/common/provider/chains/eth/provider.py
+++ b/electrum_gui/common/provider/chains/eth/provider.py
@@ -1,7 +1,24 @@
+from typing import Dict
+
+import eth_abi
+import eth_account
+import eth_keys
 import eth_utils
 
-from electrum_gui.common.provider.data import AddressValidation
+from electrum_gui.common.basic.functional.require import require
+from electrum_gui.common.provider.chains.eth import Geth
+from electrum_gui.common.provider.data import AddressValidation, SignedTx, UnsignedTx
 from electrum_gui.common.provider.interfaces import ProviderInterface
+from electrum_gui.common.secret.interfaces import SignerInterface, VerifierInterface
+
+
+class _EthKey(object):
+    def __init__(self, signer: SignerInterface):
+        self.signer = signer
+
+    def sign_msg_hash(self, digest: bytes):
+        sig, rec_id = self.signer.sign(digest)
+        return eth_keys.keys.Signature(sig + bytes([rec_id]))
 
 
 class ETHProvider(ProviderInterface):
@@ -14,3 +31,81 @@ class ETHProvider(ProviderInterface):
             is_valid, encoding = True, "hex"
 
         return AddressValidation(is_valid=is_valid, encoding=encoding)
+
+    def pubkey_to_address(self, verifier: VerifierInterface, encoding: str = None) -> str:
+        pubkey = verifier.pubkey(compressed=False)
+        address = eth_utils.add_0x_prefix(eth_utils.keccak(pubkey[-64:])[-20:].hex())  # noqa
+        return address
+
+    @property
+    def geth(self) -> Geth:
+        return self.client_selector(instance_required=Geth)
+
+    def filling_unsigned_tx(self, unsigned_tx: UnsignedTx) -> UnsignedTx:
+        fee_price_per_unit = unsigned_tx.fee_price_per_unit or self.client.get_price_per_unit_of_fee().normal.price
+        nonce = unsigned_tx.nonce
+        payload = unsigned_tx.payload.copy()
+        tx_input = unsigned_tx.inputs[0] if unsigned_tx.inputs else None
+        tx_output = unsigned_tx.outputs[0] if unsigned_tx.outputs else None
+        fee_limit = unsigned_tx.fee_limit or 21000
+
+        if tx_input is not None and tx_output is not None:
+            from_address = tx_input.address
+            to_address = tx_output.address
+            value = tx_output.value
+            token_address = tx_output.token_address
+
+            if nonce is None:
+                nonce = self.client.get_address(from_address).nonce
+
+            if token_address is None:
+                data = payload.get("data")
+            else:
+                data = eth_utils.add_0x_prefix(
+                    "a9059cbb" + eth_abi.encode_abi(("address", "uint256"), (to_address, value)).hex()
+                )  # method_selector(transfer) + byte32_pad(address) + byte32_pad(value)
+                value = 0
+                to_address = token_address
+
+            if data:
+                payload["data"] = data
+            if token_address or self.geth.is_contract(to_address):
+                estimate_fee_limit = self.geth.estimate_gas_limit(from_address, to_address, value, data)
+                estimate_fee_limit = round(estimate_fee_limit * 1.2)
+                fee_limit = max(fee_limit, estimate_fee_limit)
+
+        return unsigned_tx.clone(
+            inputs=[tx_input] if tx_input is not None else [],
+            outputs=[tx_output] if tx_output is not None else [],
+            fee_limit=fee_limit,
+            fee_price_per_unit=fee_price_per_unit,
+            nonce=nonce,
+            payload=payload,
+        )
+
+    def sign_transaction(self, unsigned_tx: UnsignedTx, key_mapping: Dict[str, SignerInterface]) -> SignedTx:
+        require(len(unsigned_tx.inputs) == 1 and len(unsigned_tx.outputs) == 1)
+        from_address = unsigned_tx.inputs[0].address
+        require(key_mapping.get(from_address) is not None)
+
+        eth_key = _EthKey(key_mapping[from_address])
+
+        output = unsigned_tx.outputs[0]
+        is_erc20_transfer = bool(output.token_address)
+        to_address = output.token_address if is_erc20_transfer else output.address
+        value = 0 if is_erc20_transfer else output.value
+        tx_dict = {
+            "to": eth_utils.to_checksum_address(to_address),
+            "value": value,
+            "gas": unsigned_tx.fee_limit,
+            "gasPrice": unsigned_tx.fee_price_per_unit,
+            "nonce": unsigned_tx.nonce,
+            "data": eth_utils.add_0x_prefix(unsigned_tx.payload.get("data") or "0x"),
+            "chainId": int(self.chain_info.chain_id),
+        }
+
+        _, _, _, encoded_tx = eth_account.account.sign_transaction_dict(eth_key, tx_dict)
+        return SignedTx(
+            txid=eth_utils.add_0x_prefix(eth_utils.keccak(encoded_tx).hex()),  # noqa
+            raw_tx=eth_utils.add_0x_prefix(encoded_tx.hex()),
+        )

--- a/electrum_gui/common/provider/chains/eth/provider.py
+++ b/electrum_gui/common/provider/chains/eth/provider.py
@@ -6,11 +6,11 @@ from electrum_gui.common.provider.interfaces import ProviderInterface
 
 class ETHProvider(ProviderInterface):
     def verify_address(self, address: str) -> AddressValidation:
-        is_valid, address_format = False, None
+        is_valid, encoding = False, None
 
         if eth_utils.is_checksum_formatted_address(address) and eth_utils.is_checksum_address(address):
-            is_valid, address_format = True, "checksum"
+            is_valid, encoding = True, "checksum"
         elif eth_utils.is_hex_address(address):
-            is_valid, address_format = True, "hex"
+            is_valid, encoding = True, "hex"
 
-        return AddressValidation(is_valid=is_valid, format=address_format)
+        return AddressValidation(is_valid=is_valid, encoding=encoding)

--- a/electrum_gui/common/provider/chains/eth/provider.py
+++ b/electrum_gui/common/provider/chains/eth/provider.py
@@ -33,7 +33,7 @@ class ETHProvider(ProviderInterface):
         return AddressValidation(is_valid=is_valid, encoding=encoding)
 
     def pubkey_to_address(self, verifier: VerifierInterface, encoding: str = None) -> str:
-        pubkey = verifier.pubkey(compressed=False)
+        pubkey = verifier.get_pubkey(compressed=False)
         address = eth_utils.add_0x_prefix(eth_utils.keccak(pubkey[-64:])[-20:].hex())  # noqa
         return address
 

--- a/electrum_gui/common/provider/chains/eth/test_provider.py
+++ b/electrum_gui/common/provider/chains/eth/test_provider.py
@@ -1,0 +1,280 @@
+from unittest import TestCase
+from unittest.mock import Mock
+
+from electrum_gui.common.provider.chains.eth import ETHProvider, Geth
+from electrum_gui.common.provider.data import (
+    AddressValidation,
+    EstimatedTimeOnPrice,
+    PricePerUnit,
+    SignedTx,
+    TransactionInput,
+    TransactionOutput,
+    UnsignedTx,
+)
+
+
+class TestETHProvider(TestCase):
+    def setUp(self) -> None:
+        self.fake_chain_info = Mock()
+        self.fake_coins_loader = Mock()
+        self.fake_client_selector = Mock()
+        self.provider = ETHProvider(
+            chain_info=self.fake_chain_info,
+            coins_loader=self.fake_coins_loader,
+            client_selector=self.fake_client_selector,
+        )
+
+    def test_verify_address(self):
+        self.assertEqual(
+            self.provider.verify_address("0x2E5124C037871DeB014490C37a4844F7019f38bD"),
+            AddressValidation(is_valid=True, encoding="checksum"),
+        )
+        self.assertEqual(
+            self.provider.verify_address("0x2e5124c037871deb014490c37a4844f7019f38bd"),
+            AddressValidation(is_valid=True, encoding="hex"),
+        )
+        self.assertEqual(self.provider.verify_address(""), AddressValidation(is_valid=False))
+        self.assertEqual(self.provider.verify_address("0x"), AddressValidation(is_valid=False))
+
+    def test_pubkey_to_address(self):
+        verifier = Mock(get_pubkey=Mock(return_value=b"\4" + b"\0" * 64))
+        self.assertEqual(
+            self.provider.pubkey_to_address(verifier=verifier), "0x3f17f1962b36e491b30a40b2405849e597ba5fb5"
+        )
+        verifier.get_pubkey.assert_called_once_with(compressed=False)
+
+    def test_filling_unsigned_tx(self):
+        external_address_a = "0x71df3bb810127271d400f7be99cc1f4504ab4c1a"
+        external_address_b = "0xa305fab8bda7e1638235b054889b3217441dd645"
+        contract_address = "0x0000000037871deb014490c37a4844f7019f38bd"
+
+        fake_client = Mock(
+            get_price_per_unit_of_fee=Mock(
+                return_value=PricePerUnit(
+                    slow=EstimatedTimeOnPrice(price=int(20 * 1e9)),
+                    normal=EstimatedTimeOnPrice(price=int(30 * 1e9)),
+                    fast=EstimatedTimeOnPrice(price=int(50 * 1e9)),
+                )
+            ),
+            get_address=Mock(return_value=Mock(nonce=11)),
+        )
+        fake_geth = Mock(
+            is_contract=Mock(side_effect=lambda address: address == contract_address),
+            estimate_gas_limit=Mock(return_value=60000),
+        )
+
+        def _client_selector_side_effect(**kwargs):
+            instance_required = kwargs.get("instance_required")
+            if instance_required and issubclass(instance_required, Geth):
+                return fake_geth
+            else:
+                return fake_client
+
+        self.fake_client_selector.side_effect = _client_selector_side_effect
+
+        with self.subTest("Empty UnsignedTx"):
+            self.assertEqual(
+                self.provider.filling_unsigned_tx(
+                    UnsignedTx(),
+                ),
+                UnsignedTx(fee_limit=21000, fee_price_per_unit=int(30 * 1e9)),
+            )
+            fake_client.get_price_per_unit_of_fee.assert_called_once()
+            fake_client.get_address.assert_not_called()
+            fake_geth.is_contract.assert_not_called()
+            fake_geth.estimate_gas_limit.assert_not_called()
+
+            fake_client.get_price_per_unit_of_fee.reset_mock()
+
+        with self.subTest("Transfer ETH to external address with preset gas price"):
+            self.assertEqual(
+                self.provider.filling_unsigned_tx(
+                    UnsignedTx(
+                        inputs=[TransactionInput(address=external_address_a, value=21)],
+                        outputs=[TransactionOutput(address=external_address_b, value=21)],
+                        fee_price_per_unit=int(102 * 1e9),
+                    )
+                ),
+                UnsignedTx(
+                    inputs=[TransactionInput(address=external_address_a, value=21)],
+                    outputs=[TransactionOutput(address=external_address_b, value=21)],
+                    nonce=11,
+                    fee_price_per_unit=int(102 * 1e9),
+                    fee_limit=21000,
+                ),
+            )
+            fake_client.get_price_per_unit_of_fee.assert_not_called()
+            fake_client.get_address.assert_called_once_with(external_address_a)
+            fake_geth.is_contract.assert_called_once_with(external_address_b)
+            fake_geth.estimate_gas_limit.assert_not_called()
+
+            fake_client.get_address.reset_mock()
+            fake_geth.is_contract.reset_mock()
+
+        with self.subTest("Transfer ETH to contract address with preset nonce"):
+            self.assertEqual(
+                self.provider.filling_unsigned_tx(
+                    UnsignedTx(
+                        inputs=[TransactionInput(address=external_address_a, value=21)],
+                        outputs=[TransactionOutput(address=contract_address, value=21)],
+                        nonce=101,
+                    )
+                ),
+                UnsignedTx(
+                    inputs=[TransactionInput(address=external_address_a, value=21)],
+                    outputs=[TransactionOutput(address=contract_address, value=21)],
+                    nonce=101,
+                    fee_price_per_unit=int(30 * 1e9),
+                    fee_limit=int(60000 * 1.2),
+                ),
+            )
+            fake_client.get_price_per_unit_of_fee.assert_called_once()
+            fake_client.get_address.assert_not_called()
+            fake_geth.is_contract.assert_called_once_with(contract_address)
+            fake_geth.estimate_gas_limit.assert_called_once_with(external_address_a, contract_address, 21, None)
+
+            fake_client.get_price_per_unit_of_fee.reset_mock()
+            fake_geth.is_contract.reset_mock()
+            fake_geth.estimate_gas_limit.reset_mock()
+
+        with self.subTest("Transfer ERC20 with preset gas price and lower gas limit"):
+            erc20_transfer_data = "0xa9059cbb000000000000000000000000a305fab8bda7e1638235b054889b3217441dd6450000000000000000000000000000000000000000000000000000000000000015"
+            self.assertEqual(
+                self.provider.filling_unsigned_tx(
+                    UnsignedTx(
+                        inputs=[
+                            TransactionInput(
+                                address=external_address_a,
+                                value=21,
+                                token_address=contract_address,
+                            )
+                        ],
+                        outputs=[
+                            TransactionOutput(
+                                address=external_address_b,
+                                value=21,
+                                token_address=contract_address,
+                            )
+                        ],
+                        fee_price_per_unit=int(102 * 1e9),
+                        fee_limit=40000,
+                    )
+                ),
+                UnsignedTx(
+                    inputs=[
+                        TransactionInput(
+                            address=external_address_a,
+                            value=21,
+                            token_address=contract_address,
+                        )
+                    ],
+                    outputs=[
+                        TransactionOutput(
+                            address=external_address_b,
+                            value=21,
+                            token_address=contract_address,
+                        )
+                    ],
+                    nonce=11,
+                    fee_price_per_unit=int(102 * 1e9),
+                    fee_limit=int(60000 * 1.2),  # Update to the latest estimated gas limit and keep 20% buffer
+                    payload={"data": erc20_transfer_data},
+                ),
+            )
+            fake_client.get_price_per_unit_of_fee.assert_not_called()
+            fake_client.get_address.assert_called_once_with(external_address_a)
+            fake_geth.is_contract.assert_not_called()
+            fake_geth.estimate_gas_limit.assert_called_once_with(
+                external_address_a, contract_address, 0, erc20_transfer_data
+            )
+
+            fake_client.get_address.reset_mock()
+            fake_geth.estimate_gas_limit.reset_mock()
+
+    def test_sign_transaction(self):
+        self.fake_chain_info.chain_id = 1
+
+        with self.subTest("Sign ETH Transfer Tx"):
+            fake_signer = Mock(
+                sign=Mock(
+                    return_value=(
+                        bytes.fromhex(
+                            "18c8df4036ef8e80434b789d84e14bbbc4db461bfcc14ffdf4faf4784cd8bf4f557d08ae22b87620bbadfb75e27a33ce4fb03aabd95c30925b4483315ab4493f"
+                        ),
+                        0,
+                    )
+                )
+            )
+            key_mapping = {"0x71df3bb810127271d400f7be99cc1f4504ab4c1a": fake_signer}
+            self.assertEqual(
+                self.provider.sign_transaction(
+                    UnsignedTx(
+                        inputs=[
+                            TransactionInput(
+                                address="0x71df3bb810127271d400f7be99cc1f4504ab4c1a", value=14995659910000000000
+                            )
+                        ],
+                        outputs=[
+                            TransactionOutput(
+                                address="0xa305fab8bda7e1638235b054889b3217441dd645", value=14995659910000000000
+                            )
+                        ],
+                        nonce=0,
+                        fee_limit=21000,
+                        fee_price_per_unit=107670000000,
+                    ),
+                    key_mapping,
+                ),
+                SignedTx(
+                    txid="0xd27c78c026978846312d70cb56f8e2863b5480a37159dab9e22fb8cdd5127469",
+                    raw_tx="0xf86c80851911a1d18082520894a305fab8bda7e1638235b054889b3217441dd64588d01b493cdc1dbc008025a018c8df4036ef8e80434b789d84e14bbbc4db461bfcc14ffdf4faf4784cd8bf4fa0557d08ae22b87620bbadfb75e27a33ce4fb03aabd95c30925b4483315ab4493f",
+                ),
+            )
+            fake_signer.sign.assert_called_once_with(
+                bytes.fromhex("6aa4f3fdc54226f2f47593ee65addbf5f7f698e42c2cdca878e2feab197083e0")
+            )
+
+        with self.subTest("Sign ERC20 Transfer Tx"):
+            fake_signer = Mock(
+                sign=Mock(
+                    return_value=(
+                        bytes.fromhex(
+                            "ff00510948d652626624d8f518309a66f7ec2149da47735f378e90c267c579f822afc54c308fcddd4a19b313ecf03be9ee328e670e9109f141902dd89e43aaf7"
+                        ),
+                        1,
+                    )
+                )
+            )
+            key_mapping = {"0x9ce42ba2d6bb04f1e464520b044012187782f869": fake_signer}
+
+            self.assertEqual(
+                self.provider.sign_transaction(
+                    UnsignedTx(
+                        inputs=[
+                            TransactionInput(
+                                address="0x9ce42ba2d6bb04f1e464520b044012187782f869",
+                                value=13170924111,
+                                token_address="0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                            )
+                        ],
+                        outputs=[
+                            TransactionOutput(
+                                address="0xa305fab8bda7e1638235b054889b3217441dd645",
+                                value=13170924111,
+                                token_address="0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                            )
+                        ],
+                        nonce=0,
+                        fee_limit=57393,
+                        fee_price_per_unit=int(100 * 1e9),
+                        payload={
+                            "data": "0xa9059cbb000000000000000000000000a305fab8bda7e1638235b054889b3217441dd64500000000000000000000000000000000000000000000000000000003110c5a4f"
+                        },
+                    ),
+                    key_mapping,
+                ),
+                SignedTx(
+                    txid="0xaee8c4369180309b99abc48b736fbda7a70c1de014f902cb2fc2e3441a72e4fa",
+                    raw_tx="0xf8a98085174876e80082e03194a0b86991c6218b36c1d19d4a2e9eb0ce3606eb4880b844a9059cbb000000000000000000000000a305fab8bda7e1638235b054889b3217441dd64500000000000000000000000000000000000000000000000000000003110c5a4f26a0ff00510948d652626624d8f518309a66f7ec2149da47735f378e90c267c579f8a022afc54c308fcddd4a19b313ecf03be9ee328e670e9109f141902dd89e43aaf7",
+                ),
+            )

--- a/electrum_gui/common/provider/data.py
+++ b/electrum_gui/common/provider/data.py
@@ -49,10 +49,18 @@ class TransactionFee(DataClassMixin):
 
 
 @dataclass
+class UTXO(DataClassMixin):
+    txid: str
+    vout: int
+    value: int
+
+
+@dataclass
 class TransactionInput(DataClassMixin):
     address: str
     value: int
     token_address: Optional[str] = None
+    utxo: Optional[UTXO] = None
 
 
 @dataclass

--- a/electrum_gui/common/provider/data.py
+++ b/electrum_gui/common/provider/data.py
@@ -66,8 +66,8 @@ class TransactionOutput(DataClassMixin):
 class Transaction(DataClassMixin):
     txid: str
     status: TransactionStatus
-    inputs: List[TransactionInput] = field(default=list)
-    outputs: List[TransactionOutput] = field(default=list)
+    inputs: List[TransactionInput] = field(default_factory=list)
+    outputs: List[TransactionOutput] = field(default_factory=list)
     fee: TransactionFee = None
     block_header: BlockHeader = None
     raw_tx: str = ""
@@ -120,3 +120,19 @@ class PricePerUnit(DataClassMixin):
 class AddressValidation(DataClassMixin):
     is_valid: bool
     encoding: Optional[str] = None
+
+
+@dataclass
+class UnsignedTx(DataClassMixin):
+    inputs: List[TransactionInput] = field(default_factory=list)
+    outputs: List[TransactionOutput] = field(default_factory=list)
+    nonce: int = None
+    fee_limit: int = None
+    fee_price_per_unit: int = None
+    payload: dict = field(default_factory=dict)
+
+
+@dataclass
+class SignedTx(DataClassMixin):
+    txid: str
+    raw_tx: str

--- a/electrum_gui/common/provider/data.py
+++ b/electrum_gui/common/provider/data.py
@@ -119,4 +119,4 @@ class PricePerUnit(DataClassMixin):
 @dataclass
 class AddressValidation(DataClassMixin):
     is_valid: bool
-    format: Optional[str] = None
+    encoding: Optional[str] = None

--- a/electrum_gui/common/provider/interfaces.py
+++ b/electrum_gui/common/provider/interfaces.py
@@ -3,6 +3,7 @@ from typing import Callable, Dict, List, Optional
 
 from electrum_gui.common.coin.data import ChainInfo, CoinInfo
 from electrum_gui.common.provider.data import (
+    UTXO,
     Address,
     AddressValidation,
     ClientInfo,
@@ -87,6 +88,14 @@ class ClientInterface(ABC):
         :return: price per unit
         """
 
+    def utxo_can_spend(self, utxo: UTXO) -> bool:
+        """
+        Check whether the UTXO is unspent
+        :param utxo:
+        :return: is unspent or not
+        """
+        raise Exception("Unsupported")
+
 
 class SearchTransactionMixin(ABC):
     def search_txs_by_address(  # noqa
@@ -118,6 +127,17 @@ class SearchTransactionMixin(ABC):
         txids = {i.txid for i in txs}
         txids = list(txids)
         return txids
+
+
+class SearchUTXOMixin(ABC):
+    @abstractmethod
+    def search_utxos_by_address(self, address: str) -> List[UTXO]:
+        """
+        Search UTXOs by address
+        :param address: address
+        :return: list of UTXO
+        todo paginate?
+        """
 
 
 class ProviderInterface(ABC):

--- a/electrum_gui/common/provider/manager.py
+++ b/electrum_gui/common/provider/manager.py
@@ -1,18 +1,21 @@
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from electrum_gui.common.provider.data import (
     Address,
     AddressValidation,
     PricePerUnit,
+    SignedTx,
     Token,
     Transaction,
     TransactionStatus,
     TxBroadcastReceipt,
     TxPaginate,
+    UnsignedTx,
 )
 from electrum_gui.common.provider.exceptions import NoAvailableClient
 from electrum_gui.common.provider.interfaces import SearchTransactionMixin
 from electrum_gui.common.provider.loader import get_client_by_chain, get_provider_by_chain
+from electrum_gui.common.secret.interfaces import SignerInterface, VerifierInterface
 
 
 def get_address(chain_code: str, address: str) -> Address:
@@ -67,3 +70,15 @@ def get_price_per_unit_of_fee(chain_code: str) -> PricePerUnit:
 
 def verify_address(chain_code: str, address: str) -> AddressValidation:
     return get_provider_by_chain(chain_code).verify_address(address)
+
+
+def pubkey_to_address(chain_code: str, verifier: VerifierInterface, encoding: str = None) -> str:
+    return get_provider_by_chain(chain_code).pubkey_to_address(verifier, encoding=encoding)
+
+
+def filling_unsigned_tx(chain_code: str, unsigned_tx: UnsignedTx) -> UnsignedTx:
+    return get_provider_by_chain(chain_code).filling_unsigned_tx(unsigned_tx)
+
+
+def sign_transaction(chain_code: str, unsigned_tx: UnsignedTx, key_mapping: Dict[str, SignerInterface]) -> SignedTx:
+    return get_provider_by_chain(chain_code).sign_transaction(unsigned_tx, key_mapping)

--- a/electrum_gui/common/provider/manager.py
+++ b/electrum_gui/common/provider/manager.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Optional
 
 from electrum_gui.common.provider.data import (
+    UTXO,
     Address,
     AddressValidation,
     PricePerUnit,
@@ -13,7 +14,7 @@ from electrum_gui.common.provider.data import (
     UnsignedTx,
 )
 from electrum_gui.common.provider.exceptions import NoAvailableClient
-from electrum_gui.common.provider.interfaces import SearchTransactionMixin
+from electrum_gui.common.provider.interfaces import SearchTransactionMixin, SearchUTXOMixin
 from electrum_gui.common.provider.loader import get_client_by_chain, get_provider_by_chain
 from electrum_gui.common.secret.interfaces import SignerInterface, VerifierInterface
 
@@ -82,3 +83,11 @@ def filling_unsigned_tx(chain_code: str, unsigned_tx: UnsignedTx) -> UnsignedTx:
 
 def sign_transaction(chain_code: str, unsigned_tx: UnsignedTx, key_mapping: Dict[str, SignerInterface]) -> SignedTx:
     return get_provider_by_chain(chain_code).sign_transaction(unsigned_tx, key_mapping)
+
+
+def utxo_can_spend(chain_code: str, utxo: UTXO) -> bool:
+    return get_client_by_chain(chain_code).utxo_can_spend(utxo)
+
+
+def search_utxos_by_address(chain_code: str, address: str) -> List[UTXO]:
+    return get_client_by_chain(chain_code, instance_required=SearchUTXOMixin).search_utxos_by_address(address)

--- a/electrum_gui/common/secret/interfaces.py
+++ b/electrum_gui/common/secret/interfaces.py
@@ -4,7 +4,7 @@ from typing import Tuple
 
 class VerifierInterface(ABC):
     @abstractmethod
-    def pubkey(self, compressed=True) -> bytes:
+    def get_pubkey(self, compressed=True) -> bytes:
         pass
 
 

--- a/electrum_gui/common/secret/interfaces.py
+++ b/electrum_gui/common/secret/interfaces.py
@@ -1,0 +1,14 @@
+from abc import ABC, abstractmethod
+from typing import Tuple
+
+
+class VerifierInterface(ABC):
+    @abstractmethod
+    def pubkey(self, compressed=True) -> bytes:
+        pass
+
+
+class SignerInterface(VerifierInterface, ABC):
+    @abstractmethod
+    def sign(self, digest: bytes) -> Tuple[bytes, int]:
+        pass


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
1. 将 AddressValidation 的 format 重命名成 encoding，更加表意，跟后面的接口保持一致（ @liuzjalex @QuincySx  这个会影响 parse_qr 接口，帮忙检查下是否会影响 app）
2. 预先给 secret 模块加上后续实现需要用到的接口
3. 填充 ProviderInterface, 新增多个方法
4. 实现 ETHProvider, 并加上测试用例
5. 填充 BTCProvider，后续再实现（不填充就无法构建实例，影响正常业务）
6. 填充 UTXO 相关接口

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
…

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
…

## Any other comments?
…
