### PR TITLE
Chainlist 支持2 - 清理pywalib以合并配置文件

### DIFF
--- a/electrum/eth_servers.json
+++ b/electrum/eth_servers.json
@@ -1,15 +1,9 @@
 {
   "eth": {
     "id": "eth",
-    "name": "Ethereum",
     "coinId": 60,
     "addressType": 44,
     "symbol": "ETH",
-    "decimals": 18,
-    "blockchain": "Ethereum",
-    "curve": "secp256k1",
-    "publicKeyType": "secp256k1Extended",
-    "derived_info": "",
     "Provider": [
       {"mainnet": "https://rpc.blkdb.cn/eth", "chainid": "1"},
       {"testnet": "https://ropsten.infura.io/v3/f001ce716b6e4a33a557f74df6fe8eff", "chainid": "3"},
@@ -19,15 +13,9 @@
   },
   "heco": {
     "id": "heco",
-    "name": "Huobi ECO Chain",
     "coinId": 60,
     "addressType": 44,
     "symbol": "HT",
-    "decimals": 18,
-    "blockchain": "Heco",
-    "curve": "secp256k1",
-    "publicKeyType": "secp256k1Extended",
-    "derived_info": "",
     "Provider": [
       {"mainnet": "https://rpc.blkdb.cn/heco", "chainid": "128"},
       {"testnet": "https://testnode.onekey.so/heco", "chainid": "128"}
@@ -36,15 +24,9 @@
   },
   "bsc": {
     "id": "bsc",
-    "name": "Binance Smart Chain",
     "coinId": 60,
     "addressType": 44,
     "symbol": "BNB",
-    "decimals": 18,
-    "blockchain": "Bsc",
-    "curve": "secp256k1",
-    "publicKeyType": "secp256k1Extended",
-    "derived_info": "",
     "Provider": [
       {"mainnet": "https://rpc.blkdb.cn/bsc", "chainid": "56"},
       {"testnet": "https://data-seed-prebsc-2-s1.binance.org:8545", "chainid": "97"}

--- a/electrum/eth_wallet.py
+++ b/electrum/eth_wallet.py
@@ -847,17 +847,13 @@ class Imported_Eth_Wallet(Simple_Eth_Wallet):
 
     @classmethod
     def _create_customer_wallet(cls, ks, config, coin):
-        def import_seed_to_address(pubkey: str):
-            addr = pywalib.PyWalib.web3.toChecksumAddress(pubkey.to_address())
-            wallet.db.add_imported_address(addr, {'pubkey': str(pubkey)})
-
         db = wallet_db.WalletDB("", manual_upgrades=False)
         db.put("keystore", ks.dump())
         wallet = cls(db, None, config=config)
         wallet.coin = coin
-        pubkey = ks.get_pubkey_from_master_xpub()
-        pubkey = eth_keys.keys.PublicKey.from_compressed_bytes(pubkey)
-        import_seed_to_address(pubkey)
+        pubkey = eth_keys.keys.PublicKey.from_compressed_bytes(ks.get_pubkey_from_master_xpub())
+        addr = eth_utils.to_checksum_address(pubkey.to_address())
+        wallet.db.add_imported_address(addr, {'pubkey': str(pubkey)})
         return wallet
 
     @classmethod

--- a/electrum/pywalib.py
+++ b/electrum/pywalib.py
@@ -7,7 +7,7 @@ import sqlite3
 from contextlib import contextmanager
 from decimal import Decimal
 from os.path import expanduser
-from typing import List, Optional
+from typing import Optional
 
 import requests
 import urllib3
@@ -590,7 +590,3 @@ class PyWalib:
             output_txs.append(output_tx)
 
         return output_txs
-
-    @classmethod
-    def get_all_txid(cls, address) -> List[str]:
-        return provider_manager.search_txids_by_address(cls.get_chain_code(), address)

--- a/electrum/pywalib.py
+++ b/electrum/pywalib.py
@@ -19,7 +19,6 @@ from web3 import HTTPProvider, Web3
 from electrum.util import make_aiohttp_session
 from electrum_gui.common.provider.data import (
     TransactionStatus,
-    Address,
     TxBroadcastReceiptCode,
 )
 from electrum_gui.common.provider import provider_manager
@@ -591,10 +590,6 @@ class PyWalib:
             output_txs.append(output_tx)
 
         return output_txs
-
-    @classmethod
-    def get_address(cls, address) -> Address:
-        return provider_manager.get_address(cls.get_chain_code(), address)
 
     @classmethod
     def get_all_txid(cls, address) -> List[str]:

--- a/electrum/pywalib.py
+++ b/electrum/pywalib.py
@@ -611,38 +611,3 @@ class PyWalib:
     @classmethod
     def get_all_txid(cls, address) -> List[str]:
         return provider_manager.search_txids_by_address(cls.get_chain_code(), address)
-
-    @classmethod
-    def get_transaction_info(cls, txid) -> dict:
-        tx = provider_manager.get_transaction_by_txid(cls.get_chain_code(), txid)
-        amount = Decimal(cls.web3.fromWei(tx.outputs[0].value, "ether"))
-        fee = Decimal(cls.web3.fromWei(tx.fee.used * tx.fee.price_per_unit, "ether"))
-
-        tx_status = _("Unconfirmed")
-        show_status = [1, _("Unconfirmed")]
-        if tx.status == TransactionStatus.CONFIRM_REVERTED:
-            tx_status = _("Sending failure")
-            show_status = [2, _("Sending failure")]
-        elif tx.status == TransactionStatus.CONFIRM_SUCCESS:
-            tx_status = (
-                _("{} confirmations").format(tx.block_header.confirmations)
-                if tx.block_header and tx.block_header.confirmations > 0
-                else _("Confirmed")
-            )
-            show_status = [3, _("Confirmed")]
-
-        return {
-            'txid': txid,
-            'can_broadcast': False,
-            'amount': amount,
-            'fee': fee,
-            'description': "",
-            'tx_status': tx_status,
-            "show_status": show_status,
-            'sign_status': None,
-            'output_addr': [tx.outputs[0].address],
-            'input_addr': [tx.inputs[0].address],
-            'height': tx.block_header.block_number if tx.block_header else -2,
-            'cosigner': [],
-            'tx': tx.raw_tx,
-        }

--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -73,6 +73,7 @@ from electrum.wallet import Imported_Wallet, Standard_Wallet, Wallet
 from electrum.wallet_db import WalletDB
 from electrum_gui.android import hardware, helpers, wallet_context
 from electrum_gui.common import the_begging
+from electrum_gui.common.provider import data as provider_data
 
 from ..common.basic.functional.text import force_text
 from ..common.basic.orm.database import db
@@ -1719,18 +1720,51 @@ class AndroidCommands(commands.Commands):
         return self.get_details_info(tx, tx_list=tx_list)
 
     def get_eth_tx_info(self, tx_hash) -> str:
-        tx = self.pywalib.get_transaction_info(tx_hash)
-
         chain_code = self._coin_to_chain_code(self.wallet.coin)
-        main_coin_price = price_manager.get_last_price(chain_code, self.ccy)
-        fiat = Decimal(tx["amount"]) * main_coin_price
-        fee_fiat = Decimal(tx["fee"]) * main_coin_price
-        symbol = coin_manager.get_coin_info(coin_manager.get_chain_info(chain_code).fee_code).symbol
+        fee_code = coin_manager.get_chain_info(chain_code).fee_code
+        symbol = coin_manager.get_coin_info(fee_code).symbol
 
-        tx["amount"] = f"{tx['amount']} {symbol} ({self.daemon.fx.ccy_amount_str(fiat, True)} {self.ccy})"
-        tx["fee"] = f"{tx['fee']} {symbol} ({self.daemon.fx.ccy_amount_str(fee_fiat, True)} {self.ccy})"
+        main_coin_price = price_manager.get_last_price(fee_code, self.ccy)
+        transaction = provider_manager.get_transaction_by_txid(chain_code, tx_hash)
 
-        return json.dumps(tx, cls=DecimalEncoder)
+        if transaction.status == provider_data.TransactionStatus.CONFIRM_REVERTED:
+            tx_status = _("Sending failure")
+            show_status = [2, _("Sending failure")]
+        elif transaction.status == provider_data.TransactionStatus.CONFIRM_SUCCESS:
+            tx_status = (
+                _("{} confirmations").format(transaction.block_header.confirmations)
+                if transaction.block_header and transaction.block_header.confirmations > 0
+                else _("Confirmed")
+            )
+            show_status = [3, _("Confirmed")]
+        else:
+            tx_status = _("Unconfirmed")
+            show_status = [1, _("Unconfirmed")]
+
+        amount = Decimal(eth_utils.from_wei(transaction.outputs[0].value, "ether"))
+        fee = Decimal(eth_utils.from_wei(transaction.fee.used * transaction.fee.price_per_unit, "ether"))
+        display_amount = (
+            f"{amount} {symbol} ({self.daemon.fx.ccy_amount_str(amount * main_coin_price, True)} {self.ccy})"
+        )
+        display_fee = f"{fee} {symbol} ({self.daemon.fx.ccy_amount_str(fee * main_coin_price, True)} {self.ccy})"
+
+        ret = {
+            "txid": tx_hash,
+            "can_broadcast": False,
+            "amount": display_amount,
+            "fee": display_fee,
+            "description": "",
+            'tx_status': tx_status,
+            "show_status": show_status,
+            'sign_status': None,
+            'output_addr': [transaction.outputs[0].address],
+            'input_addr': [transaction.inputs[0].address],
+            'height': transaction.block_header.block_number if transaction.block_header else -2,
+            'cosigner': [],
+            'tx': transaction.raw_tx,
+        }
+
+        return json.dumps(ret, cls=DecimalEncoder)
 
     def get_card(self, tx_hash, tx_mined_status, delta, fee, balance):
         try:

--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -3245,46 +3245,43 @@ class AndroidCommands(commands.Commands):
                 # # value = wallets.values()[0]
                 # return wallets[key]
 
-    def update_recover_list(self, recovery_list, balance, wallet_obj, label, coin):
-        show_info = {}
-        show_info["coin"] = coin
-        show_info["blance"] = str(balance)
-        show_info["name"] = str(wallet_obj)
-        show_info["label"] = label
-        show_info["exist"] = "1" if self.daemon.get_wallet(self._wallet_path(wallet_obj.identity)) is not None else "0"
-        recovery_list.append(show_info)
-
     def filter_wallet(self):
         recovery_list = []
         for name, wallet_info in self.recovery_wallets.items():
-            try:
-                wallet = wallet_info["wallet"]
-                coin = wallet.coin
-                if coin in self.coins:
-                    with self.pywalib.override_server(self.coins[coin]):
-                        address = wallet.get_addresses()[0]
-                        try:
-                            address_info = self.pywalib.get_address(address)
-                        except Exception:
-                            address_info = None
+            wallet = wallet_info["wallet"]
+            coin = wallet.coin
+            if coin in self.coins:
+                chain_code = self._coin_to_chain_code(coin)
+                try:
+                    address_info = provider_manager.get_address(chain_code, wallet.get_addresses()[0])
+                except Exception:
+                    address_info = None
 
-                        if address_info and address_info.existing:
-                            main_coin_balance = Decimal(eth_utils.from_wei(address_info.balance, "ether"))
-                            fiat_price = price_manager.get_last_price(coin, self.ccy)
-                            fiat_str = self.daemon.fx.ccy_amount_str(main_coin_balance * fiat_price, True)
-                            balance = f"{main_coin_balance} ({fiat_str} {self.ccy})"
-                            self.update_recover_list(recovery_list, balance, wallet, wallet.get_name(), coin)
-                            continue
-                else:
-                    history = reversed(wallet.get_history())
-                    for item in history:
-                        c, u, _ = wallet.get_balance()
-                        self.update_recover_list(
-                            recovery_list, self.format_amount_and_units(c + u), wallet, wallet.get_name(), "btc"
-                        )
-                        break
-            except BaseException as e:
-                raise e
+                if address_info is None or not address_info.existing:
+                    continue
+
+                main_coin_balance = Decimal(eth_utils.from_wei(address_info.balance, "ether"))
+                fee_code = coin_manager.get_chain_info(chain_code).fee_code
+                main_coin_price = price_manager.get_last_price(fee_code, self.ccy)
+                fiat_str = self.daemon.fx.ccy_amount_str(main_coin_balance * main_coin_price, True)
+                balance = f"{main_coin_balance} ({fiat_str} {self.ccy})"
+            else:
+                history = reversed(wallet.get_history())
+                if not history:
+                    continue
+                c, u, _ = wallet.get_balance()
+                balance = self.format_amount_and_units(c + u)
+
+            recovery_list.append(
+                {
+                    "coin": coin,
+                    "blance": balance,
+                    "name": str(wallet),
+                    "label": wallet.get_name(),
+                    "exist": "1" if self.daemon.get_wallet(self._wallet_path(wallet.identity)) is not None else "0",
+                }
+            )
+
         return recovery_list
 
     def update_recovery_wallet(self, key, wallet_obj, bip39_derivation, name, coin):

--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -983,9 +983,7 @@ class AndroidCommands(commands.Commands):
 
         for val in estimate_gas_prices.values():
             val["gas_limit"] = gas_limit
-            val["fee"] = self.pywalib.web3.fromWei(
-                gas_limit * self.pywalib.web3.toWei(val["gas_price"], "gwei"), "ether"
-            )
+            val["fee"] = eth_utils.from_wei(gas_limit * eth_utils.to_wei(val["gas_price"], "gwei"), "ether")
             val["fiat"] = f"{self.daemon.fx.ccy_amount_str(Decimal(val['fee']) * last_price, True)} {self.ccy}"
 
         return estimate_gas_prices
@@ -2366,10 +2364,8 @@ class AndroidCommands(commands.Commands):
 
         signed_tx_hex = self.sign_eth_tx(
             to_addr=transaction["to"],
-            value=self.pywalib.web3.fromWei(transaction["value"], "ether") if transaction.get("value") else 0,
-            gas_price=self.pywalib.web3.fromWei(transaction["gasPrice"], "gwei")
-            if transaction.get("gasPrice")
-            else None,
+            value=eth_utils.from_wei(transaction["value"], "ether") if transaction.get("value") else 0,
+            gas_price=eth_utils.from_wei(transaction["gasPrice"], "gwei") if transaction.get("gasPrice") else None,
             gas_limit=transaction.get("gas"),
             data=transaction.get("data"),
             nonce=transaction.get("nonce"),
@@ -2392,7 +2388,7 @@ class AndroidCommands(commands.Commands):
         else:
             message_bytes = message.encode()
 
-        return PyWalib.web3.keccak(message_bytes).hex()
+        return eth_utils.keccak(message_bytes).hex()
 
     def sign_tx(self, tx, path=None, password=None):
         """
@@ -3264,7 +3260,7 @@ class AndroidCommands(commands.Commands):
                             address_info = None
 
                         if address_info and address_info.existing:
-                            main_coin_balance = Decimal(self.pywalib.web3.fromWei(address_info.balance, "ether"))
+                            main_coin_balance = Decimal(eth_utils.from_wei(address_info.balance, "ether"))
                             fiat_price = price_manager.get_last_price(coin, self.ccy)
                             fiat_str = self.daemon.fx.ccy_amount_str(main_coin_balance * fiat_price, True)
                             balance = f"{main_coin_balance} ({fiat_str} {self.ccy})"

--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -1601,11 +1601,9 @@ class AndroidCommands(commands.Commands):
         for tx in txs:
             fiat = Decimal(tx["amount"]) * amount_coin_price
             fee_fiat = Decimal(tx["fee"]) * main_coin_price
+            fee_symbol = coin_manager.get_coin_info(coin_manager.get_chain_info(chain_code).fee_code).symbol
             tx["amount"] = f"{tx['amount']} {tx['coin']} ({self.daemon.fx.ccy_amount_str(fiat, True)} {self.ccy})"
-            tx["fee"] = (
-                f"{tx['fee']} {self.pywalib.coin_symbol} "
-                f"({self.daemon.fx.ccy_amount_str(fee_fiat, True)} {self.ccy})"
-            )
+            tx["fee"] = f"{tx['fee']} {fee_symbol} ({self.daemon.fx.ccy_amount_str(fee_fiat, True)} {self.ccy})"
 
         return json.dumps(txs, cls=DecimalEncoder)
 
@@ -1722,16 +1720,15 @@ class AndroidCommands(commands.Commands):
 
     def get_eth_tx_info(self, tx_hash) -> str:
         tx = self.pywalib.get_transaction_info(tx_hash)
-        main_coin_price = price_manager.get_last_price(self._coin_to_chain_code(self.wallet.coin), self.ccy)
+
+        chain_code = self._coin_to_chain_code(self.wallet.coin)
+        main_coin_price = price_manager.get_last_price(chain_code, self.ccy)
         fiat = Decimal(tx["amount"]) * main_coin_price
         fee_fiat = Decimal(tx["fee"]) * main_coin_price
+        symbol = coin_manager.get_coin_info(coin_manager.get_chain_info(chain_code).fee_code).symbol
 
-        tx[
-            "amount"
-        ] = f"{tx['amount']} {self.pywalib.coin_symbol} ({self.daemon.fx.ccy_amount_str(fiat, True)} {self.ccy})"
-        tx[
-            "fee"
-        ] = f"{tx['fee']} {self.pywalib.coin_symbol} ({self.daemon.fx.ccy_amount_str(fee_fiat, True)} {self.ccy})"
+        tx["amount"] = f"{tx['amount']} {symbol} ({self.daemon.fx.ccy_amount_str(fiat, True)} {self.ccy})"
+        tx["fee"] = f"{tx['fee']} {symbol} ({self.daemon.fx.ccy_amount_str(fee_fiat, True)} {self.ccy})"
 
         return json.dumps(tx, cls=DecimalEncoder)
 

--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -3569,21 +3569,6 @@ class AndroidCommands(commands.Commands):
         xpub = self.get_hd_wallet_encode_seed(coin=coin.lower())
         return self.wallet_context.get_derived_num(xpub)
 
-    def delete_devired_wallet_info(self, wallet_obj, hw=False):
-        derivation = wallet_obj.get_derivation_path(wallet_obj.get_addresses()[0])
-        coin = wallet_obj.coin
-        account_id = self.get_account_id(derivation, coin)
-
-        if hw:
-            if coin == "btc":
-                xpub = wallet_obj.get_derived_master_xpub() + 'btc'
-            else:
-                xpub = wallet_obj.keystore.xpub + coin.lower()
-        else:
-            xpub = self.get_hd_wallet_encode_seed(coin=coin)
-
-        self.wallet_context.remove_derived_wallet(xpub, account_id)
-
     def get_account_id(self, path, coin):
         if coin in self.coins:
             return helpers.get_path_info(path, INDEX_POS)
@@ -4215,15 +4200,6 @@ class AndroidCommands(commands.Commands):
         except BaseException as e:
             raise BaseException(e)
 
-    def has_history_wallet(self, wallet_obj):
-        coin = wallet_obj.coin
-        if coin in self.coins:
-            txids = self.pywalib.get_all_txid(wallet_obj.get_addresses()[0])
-            return bool(txids)
-        elif coin == "btc":
-            history = wallet_obj.get_history()
-            return bool(history)
-
     def reset_config_info(self):
         self.wallet_context.clear_type_info()
         self.wallet_context.clear_derived_info()
@@ -4250,10 +4226,32 @@ class AndroidCommands(commands.Commands):
             raise e
 
     def delete_wallet_devired_info(self, wallet_obj, hw=False):
-        have_tx = self.has_history_wallet(wallet_obj)
-        if not have_tx:
-            # delete wallet info from config
-            self.delete_devired_wallet_info(wallet_obj, hw=hw)
+        coin = wallet_obj.coin
+        if coin in self.coins:
+            # TODO: try implementing get_history for eth wallets.
+            chain_code = self._coin_to_chain_code(coin)
+            history = provider_manager.search_txids_by_address(chain_code, wallet_obj.get_addresses()[0])
+        elif coin == "btc":
+            history = wallet_obj.get_history()
+        else:
+            return
+
+        if history:
+            return
+
+        # delete wallet info from config
+        derivation = wallet_obj.get_derivation_path(wallet_obj.get_addresses()[0])
+        account_id = self.get_account_id(derivation, coin)
+
+        if hw:
+            if coin == "btc":
+                xpub = wallet_obj.get_derived_master_xpub() + 'btc'
+            else:
+                xpub = wallet_obj.keystore.xpub + coin.lower()
+        else:
+            xpub = self.get_hd_wallet_encode_seed(coin=coin)
+
+        self.wallet_context.remove_derived_wallet(xpub, account_id)
 
     def delete_wallet(self, password="", name="", hd=None):
         """

--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -13,6 +13,7 @@ import urllib.parse
 from code import InteractiveConsole
 from decimal import Decimal
 from os.path import exists, join
+from typing import Dict, List, Optional, Tuple
 
 import eth_utils
 from eth_account import Account
@@ -28,7 +29,7 @@ from electrum.bip32 import convert_bip32_path_to_list_of_uint32 as parse_path
 from electrum.bip32 import get_uncompressed_key
 from electrum.bitcoin import COIN, is_address
 from electrum.constants import read_json
-from electrum.eth_wallet import Eth_Wallet, Imported_Eth_Wallet, Standard_Eth_Wallet
+from electrum.eth_wallet import Abstract_Eth_Wallet, Eth_Wallet, Imported_Eth_Wallet, Standard_Eth_Wallet
 from electrum.i18n import _, set_language
 from electrum.interface import ServerAddr
 from electrum.keystore import (
@@ -319,32 +320,9 @@ class AndroidCommands(commands.Commands):
         out = dict()
 
         if coin in self.coins:  # eth base
-            address = eth_utils.to_checksum_address(address)
-            balance_info = self.wallet.get_all_balance(address, self.coins[coin]["symbol"])
-            balance_info = self._fill_balance_info_with_fiat(self.wallet.coin, balance_info)
-            sum_fiat = sum(i.get("fiat", 0) for i in balance_info.values())
-            main_coin_balance_info = balance_info.pop(coin, dict())
-
-            out["coin"] = main_coin_balance_info.get("symbol")
-            out["address"] = address
-            out["icon"] = self._get_icon_by_token(coin)
-            out["balance"] = main_coin_balance_info.get("balance", "0")
-            out["fiat"] = f"{self.daemon.fx.ccy_amount_str(main_coin_balance_info.get('fiat') or 0, True)} {self.ccy}"
-            sorted_tokens = sorted(
-                balance_info.values(),
-                key=lambda i: (Decimal(i.get("fiat", 0)), Decimal(i.get("balance", 0))),
-                reverse=True,
-            )
-            out["tokens"] = [
-                {
-                    "coin": i.get("symbol"),
-                    "address": i.get("address"),
-                    "icon": self._get_icon_by_token(coin, i.get("address")),
-                    "balance": i.get("balance", "0"),
-                    "fiat": f"{self.daemon.fx.ccy_amount_str(i.get('fiat') or 0, True)} {self.ccy}",
-                }
-                for i in sorted_tokens
-            ]
+            main_balance_info, contracts_balance_info, sum_fiat = self._get_eth_wallet_all_balance(self.wallet)
+            out = main_balance_info
+            out["tokens"] = contracts_balance_info
             out["sum_fiat"] = f"{self.daemon.fx.ccy_amount_str(sum_fiat, True)} {self.ccy}"
             out["btc_asset"] = self._fill_balance_info_with_btc(sum_fiat)
         elif (
@@ -3662,39 +3640,14 @@ class AndroidCommands(commands.Commands):
             all_wallet_info = []
             for wallet in self.daemon.get_wallets().values():
                 wallet_info = {"name": wallet.get_name(), "label": str(wallet)}
-                sum_fiat = Decimal(0)
                 coin = wallet.coin
                 wallet_info["coin"] = coin
                 if coin in self.coins:
-                    with self.pywalib.override_server(self.coins[coin]):
-                        checksum_from_address = eth_utils.to_checksum_address(wallet.get_addresses()[0])
-                        balances_info = wallet.get_all_balance(checksum_from_address, self.coins[coin]["symbol"])
-                        balances_info = self._fill_balance_info_with_fiat(wallet.coin, balances_info)
-                        sorted_balances = [balances_info.pop(coin, {})]
-                        sorted_balances.extend(
-                            sorted(
-                                balances_info.values(),
-                                key=lambda i: (Decimal(i.get("fiat", 0)), Decimal(i.get("balance", 0))),
-                                reverse=True,
-                            )
-                        )
-                        wallet_balances = []
-                        for info in sorted_balances:
-                            fiat = info.get("fiat") or 0
-                            copied_info = {
-                                "coin": info.get("symbol") or coin,
-                                "address": info.get("address"),
-                                "icon": self._get_icon_by_token(coin, info.get("address")),
-                                "balance": info.get("balance", "0"),
-                                "fiat": f"{self.daemon.fx.ccy_amount_str(fiat, True)} {self.ccy}",
-                            }
-                            wallet_balances.append(copied_info)
-                            sum_fiat += fiat
-                            all_balance += fiat
-
-                        wallet_info["wallets"] = wallet_balances
-                        wallet_info["sum_fiat"] = sum_fiat
-                        all_wallet_info.append(wallet_info)
+                    main_balance_info, contracts_balance_info, sum_fiat = self._get_eth_wallet_all_balance(wallet)
+                    wallet_info["wallets"] = [main_balance_info] + contracts_balance_info
+                    wallet_info["sum_fiat"] = sum_fiat
+                    all_balance += sum_fiat
+                    all_wallet_info.append(wallet_info)
                 else:
                     c, u, x = wallet.get_balance()
                     balance = c + u
@@ -3728,7 +3681,7 @@ class AndroidCommands(commands.Commands):
 
             all_wallet_info = [*no_zero_balance_wallets, *zero_balance_wallets]
 
-            out["all_balance"] = "%s %s" % (all_balance, self.ccy)
+            out["all_balance"] = f"{self.daemon.fx.ccy_amount_str(all_balance, True)} {self.ccy}"
             out["btc_asset"] = self._fill_balance_info_with_btc(all_balance)
             out["wallet_info"] = all_wallet_info
             return json.dumps(out, cls=DecimalEncoder)
@@ -4071,37 +4024,12 @@ class AndroidCommands(commands.Commands):
         self._assert_wallet_isvalid()
         coin = self.wallet.coin
         if coin in self.coins:
-            addrs = self.wallet.get_addresses()
-            checksum_from_address = eth_utils.to_checksum_address(addrs[0])
-            balance_info = self.wallet.get_all_balance(checksum_from_address, self.coins[coin]["symbol"])
-            balance_info = self._fill_balance_info_with_fiat(self.wallet.coin, balance_info)
-            sum_fiat = sum(i.get("fiat", 0) for i in balance_info.values())
-            btc_asset = self._fill_balance_info_with_btc(sum_fiat)
-            sum_fiat = f"{self.daemon.fx.ccy_amount_str(sum_fiat, True)} {self.ccy}"
-
-            sorted_balances = [balance_info.pop(coin, {})]
-            sorted_balances.extend(
-                sorted(
-                    balance_info.values(),
-                    key=lambda i: (Decimal(i.get("fiat", 0)), Decimal(i.get("balance", 0))),
-                    reverse=True,
-                )
-            )
-            wallet_balances = [
-                {
-                    "coin": i.get("symbol") or coin,
-                    "address": i.get("address"),
-                    "icon": self._get_icon_by_token(coin, i.get("address")),
-                    "balance": i.get("balance", "0"),
-                    "fiat": f"{self.daemon.fx.ccy_amount_str(i.get('fiat') or 0, True)} {self.ccy}",
-                }
-                for i in sorted_balances
-            ]
+            main_balance_info, contracts_balance_info, sum_fiat = self._get_eth_wallet_all_balance(self.wallet)
             info = {
-                "all_balance": sum_fiat,
-                "wallets": wallet_balances,
+                "all_balance": f"{self.daemon.fx.ccy_amount_str(sum_fiat, True)} {self.ccy}",
+                "wallets": [main_balance_info] + contracts_balance_info,
                 "coin": coin,
-                "btc_asset": btc_asset,
+                "btc_asset": self._fill_balance_info_with_btc(sum_fiat),
             }
         else:
             c, u, x = self.wallet.get_balance()
@@ -4150,28 +4078,14 @@ class AndroidCommands(commands.Commands):
             coin = self.wallet.coin
             if coin in self.coins:
                 PyWalib.set_server(self.coins[coin])
-                addrs = self.wallet.get_addresses()
-                checksum_from_address = eth_utils.to_checksum_address(addrs[0])
-                balance_info = self.wallet.get_all_balance(checksum_from_address, self.coins[coin]["symbol"])
-                balance_info = self._fill_balance_info_with_fiat(self.wallet.coin, balance_info)
-                sorted_balances = [balance_info.pop(coin, {})]
-                sorted_balances.extend(
-                    sorted(
-                        balance_info.values(),
-                        key=lambda i: (Decimal(i.get("fiat", 0)), Decimal(i.get("balance", 0))),
-                        reverse=True,
-                    )
+                main_balance_info, contracts_balance_info, _zero_fiat = self._get_eth_wallet_all_balance(
+                    self.wallet, with_sum_fiat=False
                 )
-                wallet_balances = [
-                    {
-                        "coin": i.get("symbol") or coin,
-                        "address": i.get("address"),
-                        "balance": i.get("balance") or "0",
-                        "fiat": f"{self.daemon.fx.ccy_amount_str(i.get('fiat') or 0, True)} {self.ccy}",
-                    }
-                    for i in sorted_balances
-                ]
-                info = {"name": name, "label": self.wallet.get_name(), "wallets": wallet_balances}
+                info = {
+                    "name": name,
+                    "label": self.wallet.get_name(),
+                    "wallets": [main_balance_info] + contracts_balance_info,
+                }
                 return json.dumps(info, cls=DecimalEncoder)
             else:
                 c, u, x = self.wallet.get_balance()
@@ -4192,20 +4106,59 @@ class AndroidCommands(commands.Commands):
         except BaseException as e:
             raise BaseException(e)
 
-    def _fill_balance_info_with_fiat(self, coin: str, balance_info: dict) -> dict:
-        main_coin_price = price_manager.get_last_price(coin, self.ccy)
-        token_addresses = [i["address"].lower() for i in balance_info.values() if i.get("address")]
-        chain_code = self._coin_to_chain_code(coin)
-        tokens = coin_manager.query_coins_by_token_addresses(chain_code, token_addresses)
-        token_prices = {i.token_address.lower(): price_manager.get_last_price(i.code, self.ccy) for i in tokens}
+    def _get_eth_wallet_all_balance(
+        self, wallet: Optional[Abstract_Eth_Wallet] = None, with_sum_fiat: bool = True
+    ) -> Tuple[Dict, List, Decimal]:
+        wallet = wallet or self.wallet
+        chain_code = self._coin_to_chain_code(wallet.coin)
+        main_balance, contracts_balance_info = wallet.get_all_balance(chain_code)
+        sum_fiat = Decimal('0')
 
-        new_balance_info = {}
-        for k, v in balance_info.items():
-            price = main_coin_price if not v.get("address") else token_prices.get(v["address"].lower())
-            price = price or Decimal(0)
-            new_balance_info[k] = {**v, "fiat": Decimal(v.get("balance") or 0) * price}
+        main_coin_code = coin_manager.get_chain_info(chain_code).fee_code
+        main_coin = coin_manager.get_coin_info(main_coin_code)
+        main_coin_price = price_manager.get_last_price(main_coin_code, self.ccy)
+        main_coin_fiat = main_balance * main_coin_price
+        if with_sum_fiat:
+            sum_fiat += main_coin_fiat
+        ret_main_balance_info = {
+            "coin": main_coin.symbol,  # The key is misleading, should be symbol
+            "address": wallet.get_addresses()[0],
+            "icon": main_coin.icon,
+            "balance": main_balance,
+            "fiat": f"{self.daemon.fx.ccy_amount_str(main_coin_fiat, True)} {self.ccy}",
+        }
 
-        return new_balance_info
+        token_addresses = [address.lower() for address in contracts_balance_info.keys()]
+        token_prices = {}
+        token_icons = {}
+        for token in coin_manager.query_coins_by_token_addresses(chain_code, token_addresses):
+            address = token.token_address.lower()
+            token_prices[address] = price_manager.get_last_price(token.code, self.ccy)
+            token_icons[address] = token.icon
+
+        ret_contracts_balance_info = []
+        _sort_helper_dict = {}
+        for address, info in contracts_balance_info.items():
+            address = address.lower()
+            fiat = info["balance"] * token_prices.get(address, 0)
+            if with_sum_fiat:
+                sum_fiat += fiat
+            ret_contracts_balance_info.append(
+                {
+                    "coin": info["symbol"],  # The key is misleading, should be symbol
+                    "address": address,
+                    "icon": token_icons.get(address, 0),
+                    "balance": info["balance"],
+                    "fiat": f"{self.daemon.fx.ccy_amount_str(fiat, True)} {self.ccy}",
+                }
+            )
+            _sort_helper_dict[address] = fiat
+
+        ret_contracts_balance_info.sort(
+            key=lambda balance_info: (_sort_helper_dict.get(balance_info["address"]), balance_info["balance"]),
+            reverse=True,
+        )
+        return ret_main_balance_info, ret_contracts_balance_info, sum_fiat
 
     def _fill_balance_info_with_btc(self, fiat: Decimal) -> str:
         price = price_manager.get_last_price("btc", self.ccy)

--- a/electrum_gui/common/provider/chains/eth/clients/blockbook.py
+++ b/electrum_gui/common/provider/chains/eth/clients/blockbook.py
@@ -15,7 +15,6 @@ from electrum_gui.common.provider.data import (
     ClientInfo,
     EstimatedTimeOnPrice,
     PricePerUnit,
-    Token,
     Transaction,
     TransactionFee,
     TransactionInput,
@@ -84,8 +83,8 @@ class BlockBook(ClientInterface, SearchTransactionMixin):
         require(resp["address"].lower() == address.lower())
         return resp
 
-    def get_balance(self, address: str, token: Token = None) -> int:
-        if not token:
+    def get_balance(self, address: str, token_address: Optional[str] = None) -> int:
+        if token_address is None:
             return super(BlockBook, self).get_balance(address)
         else:
             resp = self._get_raw_address_info(address, details="tokenBalances")
@@ -94,7 +93,7 @@ class BlockBook(ClientInterface, SearchTransactionMixin):
                 for token_dict in (resp.get("tokens") or ())
                 if token_dict.get("contract") and token_dict.get("balance")
             }
-            balance = tokens.get(token.contract.lower(), 0)
+            balance = tokens.get(token_address.lower(), 0)
             return int(balance)
 
     def get_transaction_by_txid(self, txid: str) -> Transaction:

--- a/electrum_gui/common/provider/chains/eth/clients/etherscan.py
+++ b/electrum_gui/common/provider/chains/eth/clients/etherscan.py
@@ -9,7 +9,6 @@ from electrum_gui.common.provider.data import (
     ClientInfo,
     EstimatedTimeOnPrice,
     PricePerUnit,
-    Token,
     Transaction,
     TransactionFee,
     TransactionInput,
@@ -55,11 +54,11 @@ class Etherscan(ClientInterface, SearchTransactionMixin):
         nonce = int(resp["result"], base=16)
         return Address(address=address, balance=balance, nonce=nonce, existing=(bool(balance) or bool(nonce)))
 
-    def get_balance(self, address: str, token: Token = None) -> int:
-        if not token:
+    def get_balance(self, address: str, token_address: Optional[str] = None) -> int:
+        if token_address is None:
             return super(Etherscan, self).get_balance(address)
         else:
-            resp = self._call_action("account", "tokenbalance", address=address, contractaddress=token.contract)
+            resp = self._call_action("account", "tokenbalance", address=address, contractaddress=token_address)
             return int(resp.get("result", 0))
 
     def get_transaction_by_txid(self, txid: str) -> Transaction:

--- a/electrum_gui/common/provider/chains/eth/clients/geth.py
+++ b/electrum_gui/common/provider/chains/eth/clients/geth.py
@@ -1,6 +1,6 @@
 import time
 from functools import partial
-from typing import Any
+from typing import Any, Optional
 
 import eth_utils
 
@@ -14,7 +14,6 @@ from electrum_gui.common.provider.data import (
     ClientInfo,
     EstimatedTimeOnPrice,
     PricePerUnit,
-    Token,
     Transaction,
     TransactionFee,
     TransactionInput,
@@ -54,14 +53,14 @@ class Geth(ClientInterface):
         nonce = _hex2int(_nonce)
         return Address(address=address, balance=balance, nonce=nonce, existing=(bool(balance) or bool(nonce)))
 
-    def get_balance(self, address: str, token: Token = None) -> int:
-        if not token:
+    def get_balance(self, address: str, token_address: Optional[str] = None) -> int:
+        if token_address is None:
             return super(Geth, self).get_balance(address)
         else:
             call_balance_of = (
                 "0x70a08231000000000000000000000000" + address[2:]
             )  # method_selector(balance_of) + byte32_pad(address)
-            resp = self.eth_call({"to": token.contract, "data": call_balance_of})
+            resp = self.eth_call({"to": token_address, "data": call_balance_of})
 
             try:
                 return _hex2int(resp[:66])

--- a/electrum_gui/common/provider/data.py
+++ b/electrum_gui/common/provider/data.py
@@ -99,11 +99,6 @@ class Address(DataClassMixin):
 
 
 @dataclass
-class Token(DataClassMixin):
-    contract: str
-
-
-@dataclass
 class TxBroadcastReceipt(DataClassMixin):
     is_success: bool
     receipt_code: TxBroadcastReceiptCode

--- a/electrum_gui/common/provider/interfaces.py
+++ b/electrum_gui/common/provider/interfaces.py
@@ -9,7 +9,6 @@ from electrum_gui.common.provider.data import (
     ClientInfo,
     PricePerUnit,
     SignedTx,
-    Token,
     Transaction,
     TransactionStatus,
     TxBroadcastReceipt,
@@ -44,7 +43,7 @@ class ClientInterface(ABC):
         :return: Address
         """
 
-    def get_balance(self, address: str, token: Token = None) -> int:
+    def get_balance(self, address: str, contract_address: Optional[str] = None) -> int:
         """
         get address balance
         :param address: address

--- a/electrum_gui/common/provider/manager.py
+++ b/electrum_gui/common/provider/manager.py
@@ -6,7 +6,6 @@ from electrum_gui.common.provider.data import (
     AddressValidation,
     PricePerUnit,
     SignedTx,
-    Token,
     Transaction,
     TransactionStatus,
     TxBroadcastReceipt,
@@ -23,8 +22,10 @@ def get_address(chain_code: str, address: str) -> Address:
     return get_client_by_chain(chain_code).get_address(address)
 
 
-def get_balance(chain_code: str, address: str, token: Token = None) -> int:
-    return get_client_by_chain(chain_code).get_balance(address, token=token)
+def get_balance(chain_code: str, address: str, token_address: Optional[str] = None) -> int:
+    # TODO: raise specific exceptions for callers to catch. This also applies
+    # to the APIs in this module.
+    return get_client_by_chain(chain_code).get_balance(address, token_address=token_address)
 
 
 def get_transaction_by_txid(chain_code: str, txid: str) -> Transaction:


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
- 清理原来eth_servers.json配置文件中的一些无用内容，方便后续合并
- 逐步清理console.py中对pywalib的依赖，目前这些内容还不涉及将原来的功能用provider去实现，预计下一个/几个PR来完成这个，也就能清理掉pywalib，从而所有和链交互的都会使用新的逻辑了

## Does this close any currently open issues?  
OneKeyHQ/TaskHub#1181 的一部分工作

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
N/A

## Any other comments?
剩余gas相关，transaction相关，contract相关需要把相关的逻辑移动到electrum_gui/common底下。预计下一个PR会更大，所以先review这一部分吧。