### PR TITLE
EVM networks: update RPC endpoints

### DIFF
--- a/electrum/eth_servers.json
+++ b/electrum/eth_servers.json
@@ -11,19 +11,10 @@
     "publicKeyType": "secp256k1Extended",
     "derived_info": "",
     "Provider": [
-      {"mainnet": "https://mainnet.infura.io/v3/f001ce716b6e4a33a557f74df6fe8eff", "chainid": "1"},
+      {"mainnet": "https://rpc.blkdb.cn/eth", "chainid": "1"},
       {"testnet": "https://ropsten.infura.io/v3/f001ce716b6e4a33a557f74df6fe8eff", "chainid": "3"},
       {"customer": "http://127.0.0.1:8545", "chainid": "11"}
     ],
-    "TxliServer": [
-         {"onekey-mainnet": "https://eth1.onekey.so/api/v2/"},
-         {"etherscan-mainnet": "https://api-cn.etherscan.com/api"},
-         {"etherscan-testnet": "https://api-ropsten.etherscan.io/api"},
-         {"trezor-mainnet": "https://eth1.trezor.io/api/v2/"},
-         {"trezor-mainnet1": "https://eth2.trezor.io/api/v2/"},
-         {"trezor-testnet": "https://eth1.ropsten1.trezor.io/api/v2/"},
-         {"trezor-testnet1": "https://eth2.ropsten1.trezor.io/api/v2/"}
-      ],
     "GasServer": "https://www.gasnow.org/api/v3/gas/price?utm_source=onekey"
   },
   "heco": {
@@ -38,11 +29,8 @@
     "publicKeyType": "secp256k1Extended",
     "derived_info": "",
     "Provider": [
-      {"mainnet": "https://http-mainnet-node.huobichain.com", "chainid": "128"},
+      {"mainnet": "https://rpc.blkdb.cn/heco", "chainid": "128"},
       {"testnet": "https://testnode.onekey.so/heco", "chainid": "128"}
-    ],
-    "TxliServer": [
-      {"onekey-mainnet": "https://heco1.onekey.so/api/v2/"}
     ],
     "GasServer": ""
   },
@@ -58,11 +46,8 @@
     "publicKeyType": "secp256k1Extended",
     "derived_info": "",
     "Provider": [
-      {"mainnet": "https://bsc-dataseed1.binance.org", "chainid": "56"},
+      {"mainnet": "https://rpc.blkdb.cn/bsc", "chainid": "56"},
       {"testnet": "https://data-seed-prebsc-2-s1.binance.org:8545", "chainid": "97"}
-    ],
-    "TxliServer": [
-      {"onekey-mainnet": "https://bsc1.onekey.so/api/v2/"}
     ],
     "GasServer": ""
   },
@@ -75,7 +60,6 @@
       {"mainnet": "https://exchain.okexcn.com/", "chainid": "66"},
       {"testnet": "https://exchaintest.okexcn.com/", "chainid": "65"}
     ],
-    "TxliServer": [],
     "GasServer": ""
   }
 }

--- a/electrum/pywalib.py
+++ b/electrum/pywalib.py
@@ -175,7 +175,6 @@ class PyWalib:
     server_config = None
     coin_symbol = None
     web3 = None
-    tx_list_server = None
     gas_server = None
     symbols_price = {}
     config = None
@@ -212,7 +211,6 @@ class PyWalib:
 
     @staticmethod
     def set_server(info):
-        PyWalib.tx_list_server = info['TxliServer']
         PyWalib.gas_server = info['GasServer']
         PyWalib.coin_symbol = info["symbol"]
         PyWalib.server_config = info

--- a/electrum_gui/common/coin/configs/chains.json
+++ b/electrum_gui/common/coin/configs/chains.json
@@ -33,6 +33,10 @@
     "clients": [
       {
         "class": "Geth",
+        "url": "https://rpc.blkdb.cn/eth"
+      },
+      {
+        "class": "Geth",
         "url": "https://eth1.onekey.so/rpc"
       },
       {
@@ -79,6 +83,10 @@
     "clients": [
       {
         "class": "Geth",
+        "url": "https://rpc.blkdb.cn/bsc"
+      },
+      {
+        "class": "Geth",
         "url": "https://bsc1.onekey.so/rpc"
       },
       {
@@ -105,6 +113,10 @@
       }
     ],
     "clients": [
+      {
+        "class": "Geth",
+        "url": "https://rpc.blkdb.cn/heco"
+      },
       {
         "class": "Geth",
         "url": "https://heco1.onekey.so/rpc"


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
更新RPC endpoint为代理缓存的节点。
另外清理掉pywalib残留的无用属性，历史记录已经用新的逻辑用blockbook或者etherscan的实现来获取了。

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
No

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): RPC 节点信息更新

## Where has this been tested?
N/A

## Any other comments?
No
