### PR TITLE
Support for BTC type wallets derived from address types

### DIFF
--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -503,6 +503,15 @@ class AndroidCommands(commands.Commands):
                 wallet.start_network(self.network)
             if self.wallet_context.is_hd(name):
                 self.set_hd_wallet(wallet)
+                bip39_derivation = wallet.get_derivation_path(wallet.get_addresses()[0])
+                self.update_devired_wallet_info(
+                    bip39_derivation,
+                    self.get_hd_wallet_encode_seed(
+                        coin=wallet.coin, purpose=helpers.get_path_info(bip39_derivation, PURPOSE_POS)
+                    ),
+                    wallet.name,
+                    wallet.coin,
+                )
             self.daemon.add_wallet(wallet)
         return wallet
 
@@ -3568,7 +3577,7 @@ class AndroidCommands(commands.Commands):
                 xpub = self.get_hd_wallet_encode_seed(coin=coin, purpose=add_type)
                 derived_num += self.wallet_context.get_derived_num(xpub)
         elif coin in self.coins:
-            add_type = self.coins[coin]["addressType"]
+            add_type = str(self.coins[coin]["addressType"])
             xpub = self.get_hd_wallet_encode_seed(coin=coin, purpose=add_type)
             derived_num = self.wallet_context.get_derived_num(xpub)
         return derived_num

--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -2884,7 +2884,7 @@ class AndroidCommands(commands.Commands):
             self.update_devired_wallet_info(
                 bip39_derivation,
                 self.get_hd_wallet_encode_seed(
-                    seed=seed, coin=wallet.coin, type=helpers.get_path_info(bip39_derivation, PURPOSE_POS)
+                    seed=seed, coin=wallet.coin, purpose=helpers.get_path_info(bip39_derivation, PURPOSE_POS)
                 ),
                 wallet.name,
                 wallet.coin,
@@ -2900,7 +2900,7 @@ class AndroidCommands(commands.Commands):
             account_id = 0
         return account_id
 
-    def get_default_show_path(self, hw=False, coin=None, derived=False, purpose=None, path="android_usb"):
+    def get_default_show_path(self, hw=False, coin=None, derived=False, purpose="49", path="android_usb"):
         """
         Get the default path for creating a wallet
         :param hw: if true, it means that you currently need to create a hardware wallet
@@ -2912,10 +2912,10 @@ class AndroidCommands(commands.Commands):
         """
         account_id = 0
         if not hw and derived:
-            derive_key = self.get_hd_wallet_encode_seed(coin=coin, type=str(purpose))
+            derive_key = self.get_hd_wallet_encode_seed(coin=coin, purpose=str(purpose))
             account_id = self._get_derived_account_id(derive_key)
         elif hw:
-            xpub = self.get_xpub_from_hw(path=path, coin=coin, _type=PURPOSE_TO_ADDRESS_TYPE.get(purpose, ""))
+            xpub = self.get_xpub_from_hw(path=path, coin=coin, _type=PURPOSE_TO_ADDRESS_TYPE.get(purpose, "p2wpkh"))
             account_id = self._get_derived_account_id(xpub + coin.lower(), hw=hw)
 
         if coin.lower() == 'btc':
@@ -3349,14 +3349,14 @@ class AndroidCommands(commands.Commands):
 
         return self.hd_wallet
 
-    def get_hd_wallet_encode_seed(self, seed=None, coin="", passphrase="", type=""):
+    def get_hd_wallet_encode_seed(self, seed=None, coin="", passphrase="", purpose=""):
         if seed is not None:
             path = bip44_derivation(0, 84)
             ks = keystore.from_bip39_seed(seed, passphrase, path)
             self.config.set_key("current_hd_xpub", ks.xpub)
-            return ks.xpub + coin.lower() + type
+            return ks.xpub + coin.lower() + purpose
         else:
-            return self.config.get("current_hd_xpub", "") + coin.lower() + type
+            return self.config.get("current_hd_xpub", "") + coin.lower() + purpose
 
     @classmethod
     def _set_recovery_flag(cls, flag=False):
@@ -3449,15 +3449,15 @@ class AndroidCommands(commands.Commands):
                 with PyWalib.override_server(info):
                     recovery_wallet(self, coin=coin)
         else:
-            for type in ["49", "44", "84"]:
-                xpub = self.get_hd_wallet_encode_seed(seed=seed, coin="btc", type=type)
-                recovery_wallet(self, purpose=type)
+            for add_type in ["49", "44", "84"]:
+                xpub = self.get_hd_wallet_encode_seed(seed=seed, coin="btc", purpose=add_type)
+                recovery_wallet(self, purpose=add_type)
 
             for coin, info in self.coins.items():
-                type = info["addressType"]
-                xpub = self.get_hd_wallet_encode_seed(seed=seed, coin=coin, type=type)
+                add_type = info["addressType"]
+                xpub = self.get_hd_wallet_encode_seed(seed=seed, coin=coin, purpose=add_type)
                 with PyWalib.override_server(info):
-                    recovery_wallet(self, coin=coin, purpose=type)
+                    recovery_wallet(self, coin=coin, purpose=add_type)
 
         recovery_list = self.filter_wallet()
         wallet_data = self.filter_wallet_with_account_is_zero()
@@ -3501,7 +3501,7 @@ class AndroidCommands(commands.Commands):
         seed = self.get_hd_wallet().get_seed(password)
         coin_type = constants.net.BIP44_COIN_TYPE if coin == "btc" else self.coins[coin]["coinId"]
         purpose = purpose if coin == "btc" else self.coins[coin]["addressType"]
-        encode_seed = self.get_hd_wallet_encode_seed(seed=seed, coin=coin, type=str(purpose))
+        encode_seed = self.get_hd_wallet_encode_seed(seed=seed, coin=coin, purpose=str(purpose))
         account_id = self._get_derived_account_id(encode_seed)
 
         if coin in self.coins:
@@ -3544,7 +3544,7 @@ class AndroidCommands(commands.Commands):
         wallet.coin = coin
         wallet.storage.set_path(self._wallet_path(wallet.identity))
         self.recovery_wallets[wallet.identity] = self.update_recovery_wallet(
-            self.get_hd_wallet_encode_seed(seed=seed, coin=coin, type=str(purpose)),
+            self.get_hd_wallet_encode_seed(seed=seed, coin=coin, purpose=str(purpose)),
             wallet,
             bip39_derivation,
             name,
@@ -3562,13 +3562,14 @@ class AndroidCommands(commands.Commands):
         :return: num as int
         """
         derived_num = 0
-        if coin.lower() == "btc":
-            for type in ["49", "84", "44"]:
-                xpub = self.get_hd_wallet_encode_seed(coin=coin.lower(), type=type)
+        coin = coin.lower()
+        if coin == "btc":
+            for add_type in ["49", "84", "44"]:
+                xpub = self.get_hd_wallet_encode_seed(coin=coin, purpose=add_type)
                 derived_num += self.wallet_context.get_derived_num(xpub)
-        elif coin.lower() in self.coins:
-            type = self.coins[coin.lower()]["addressType"]
-            xpub = self.get_hd_wallet_encode_seed(coin=coin.lower(), type=type)
+        elif coin in self.coins:
+            add_type = self.coins[coin]["addressType"]
+            xpub = self.get_hd_wallet_encode_seed(coin=coin, purpose=add_type)
             derived_num = self.wallet_context.get_derived_num(xpub)
         return derived_num
 
@@ -3584,7 +3585,7 @@ class AndroidCommands(commands.Commands):
                 xpub = wallet_obj.keystore.xpub + coin.lower()
         else:
             purpose = helpers.get_path_info(wallet_obj.get_derivation_path(), PURPOSE_POS)
-            xpub = self.get_hd_wallet_encode_seed(coin=coin, type=purpose)
+            xpub = self.get_hd_wallet_encode_seed(coin=coin, purpose=purpose)
 
         self.wallet_context.remove_derived_wallet(xpub, account_id)
 

--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -2882,7 +2882,12 @@ class AndroidCommands(commands.Commands):
         if bip39_derivation is not None:
             self.set_hd_wallet(wallet)
             self.update_devired_wallet_info(
-                bip39_derivation, self.get_hd_wallet_encode_seed(seed=seed, coin=wallet.coin), wallet.name, wallet.coin
+                bip39_derivation,
+                self.get_hd_wallet_encode_seed(
+                    seed=seed, coin=wallet.coin, type=helpers.get_path_info(bip39_derivation, PURPOSE_POS)
+                ),
+                wallet.name,
+                wallet.coin,
             )
 
     def _get_derived_account_id(self, xpub, hw=False):
@@ -2907,7 +2912,7 @@ class AndroidCommands(commands.Commands):
         """
         account_id = 0
         if not hw and derived:
-            derive_key = self.get_hd_wallet_encode_seed(coin=coin)
+            derive_key = self.get_hd_wallet_encode_seed(coin=coin, type=str(purpose))
             account_id = self._get_derived_account_id(derive_key)
         elif hw:
             xpub = self.get_xpub_from_hw(path=path, coin=coin)
@@ -3344,14 +3349,14 @@ class AndroidCommands(commands.Commands):
 
         return self.hd_wallet
 
-    def get_hd_wallet_encode_seed(self, seed=None, coin="", passphrase=""):
+    def get_hd_wallet_encode_seed(self, seed=None, coin="", passphrase="", type=""):
         if seed is not None:
             path = bip44_derivation(0, 84)
             ks = keystore.from_bip39_seed(seed, passphrase, path)
             self.config.set_key("current_hd_xpub", ks.xpub)
-            return ks.xpub + coin.lower()
+            return ks.xpub + coin.lower() + type
         else:
-            return self.config.get("current_hd_xpub", "") + coin.lower()
+            return self.config.get("current_hd_xpub", "") + coin.lower() + type
 
     @classmethod
     def _set_recovery_flag(cls, flag=False):
@@ -3391,42 +3396,39 @@ class AndroidCommands(commands.Commands):
     ):
         eths_xpub = None
 
-        def recovery_wallet(self, coin="btc") -> None:
+        def recovery_wallet(self, purpose="", coin="btc") -> None:
             def recovery_create_subfun(self, coin, account_id, name) -> None:
                 nonlocal eths_xpub
                 try:
-                    if coin == "btc":
-                        purposes = [49, 44, 84]
-                    elif coin in self.coins:
-                        purposes = [self.coins[coin]["addressType"]]
+                    if coin in self.coins:
                         if hw and eths_xpub:
                             self.recovery_import_create_hw_wallet(account_id, name, 1, 1, eths_xpub, coin=coin)
                             return
                     else:
                         raise Exception(_("unknown coin type provided"))
-                    for purpose in purposes:
-                        if not AndroidCommands._recovery_flag:
-                            self.recovery_wallets.clear()
-                            AndroidCommands._set_recovery_flag(True)
-                            raise UserCancel()
-                        if hw:
-                            _type = PURPOSE_TO_ADDRESS_TYPE.get(purpose, "")
-                            xpub = self.get_xpub_from_hw(
-                                path=path, _type=_type, account_id=account_id, coin=coin, from_recovery=True
-                            )
-                            if coin != "btc":
-                                eths_xpub = xpub
-                            self.recovery_import_create_hw_wallet(account_id, name, 1, 1, xpub, coin=coin)
-                        else:
-                            bip39_derivation = self.get_coin_derived_path(account_id, coin, purpose=purpose)
-                            self.recovery_create(
-                                name,
-                                seed,
-                                password=password,
-                                bip39_derivation=bip39_derivation,
-                                passphrase=passphrase,
-                                coin=coin,
-                            )
+
+                    if not AndroidCommands._recovery_flag:
+                        self.recovery_wallets.clear()
+                        AndroidCommands._set_recovery_flag(True)
+                        raise UserCancel()
+                    if hw:
+                        _type = PURPOSE_TO_ADDRESS_TYPE.get(purpose, "")
+                        xpub = self.get_xpub_from_hw(
+                            path=path, _type=_type, account_id=account_id, coin=coin, from_recovery=True
+                        )
+                        if coin != "btc":
+                            eths_xpub = xpub
+                        self.recovery_import_create_hw_wallet(account_id, name, 1, 1, xpub, coin=coin)
+                    else:
+                        bip39_derivation = self.get_coin_derived_path(account_id, coin, purpose=purpose)
+                        self.recovery_create(
+                            name,
+                            seed,
+                            password=password,
+                            bip39_derivation=bip39_derivation,
+                            passphrase=passphrase,
+                            coin=coin,
+                        )
                 except BaseException as e:
                     raise e
 
@@ -3447,12 +3449,15 @@ class AndroidCommands(commands.Commands):
                 with PyWalib.override_server(info):
                     recovery_wallet(self, coin=coin)
         else:
-            xpub = self.get_hd_wallet_encode_seed(seed=seed, coin="btc")
-            recovery_wallet(self)
+            for type in ["49", "44", "84"]:
+                xpub = self.get_hd_wallet_encode_seed(seed=seed, coin="btc", type=type)
+                recovery_wallet(self, purpose=type)
+
             for coin, info in self.coins.items():
-                xpub = self.get_hd_wallet_encode_seed(seed=seed, coin=coin)
+                type = info["addressType"]
+                xpub = self.get_hd_wallet_encode_seed(seed=seed, coin=coin, type=type)
                 with PyWalib.override_server(info):
-                    recovery_wallet(self, coin=coin)
+                    recovery_wallet(self, coin=coin, purpose=type)
 
         recovery_list = self.filter_wallet()
         wallet_data = self.filter_wallet_with_account_is_zero()
@@ -3496,13 +3501,13 @@ class AndroidCommands(commands.Commands):
         seed = self.get_hd_wallet().get_seed(password)
         coin_type = constants.net.BIP44_COIN_TYPE if coin == "btc" else self.coins[coin]["coinId"]
         purpose = purpose if coin == "btc" else self.coins[coin]["addressType"]
-        encode_seed = self.get_hd_wallet_encode_seed(seed=seed, coin=coin)
+        encode_seed = self.get_hd_wallet_encode_seed(seed=seed, coin=coin, type=str(purpose))
         account_id = self._get_derived_account_id(encode_seed)
 
         if coin in self.coins:
-            derivat_path = bip44_eth_derivation(account_id, purpose, cointype=coin_type)
+            derivat_path = bip44_eth_derivation(account_id, int(purpose), cointype=coin_type)
         else:
-            derivat_path = bip44_derivation(account_id, purpose)
+            derivat_path = bip44_derivation(account_id, int(purpose))
         return self.create(name, password, seed=seed, bip39_derivation=derivat_path, strength=strength, coin=coin)
 
     def recovery_create(self, name, seed, password, bip39_derivation, passphrase="", coin="btc"):
@@ -3511,8 +3516,8 @@ class AndroidCommands(commands.Commands):
         except BaseException as e:
             raise e
         account_id = int(self.get_account_id(bip39_derivation, coin))
+        purpose = int(helpers.get_path_info(bip39_derivation, PURPOSE_POS))
         if account_id == 0:
-            purpose = int(helpers.get_path_info(bip39_derivation, PURPOSE_POS))
             if purpose == 49:
                 name = "BTC-1"
             elif coin in self.coins:
@@ -3539,7 +3544,11 @@ class AndroidCommands(commands.Commands):
         wallet.coin = coin
         wallet.storage.set_path(self._wallet_path(wallet.identity))
         self.recovery_wallets[wallet.identity] = self.update_recovery_wallet(
-            self.get_hd_wallet_encode_seed(seed=seed, coin=coin), wallet, bip39_derivation, name, coin
+            self.get_hd_wallet_encode_seed(seed=seed, coin=coin, type=str(purpose)),
+            wallet,
+            bip39_derivation,
+            name,
+            coin,
         )
         wallet.update_password(old_pw=None, new_pw=password, str_pw=self.android_id, encrypt_storage=True)
         if coin == "btc":
@@ -3552,8 +3561,16 @@ class AndroidCommands(commands.Commands):
         :param coin:btc/eth as string
         :return: num as int
         """
-        xpub = self.get_hd_wallet_encode_seed(coin=coin.lower())
-        return self.wallet_context.get_derived_num(xpub)
+        derived_num = 0
+        if coin.lower() == "btc":
+            for type in ["49", "84", "44"]:
+                xpub = self.get_hd_wallet_encode_seed(coin=coin.lower(), type=type)
+                derived_num += self.wallet_context.get_derived_num(xpub)
+        elif coin.lower() in self.coins:
+            type = self.coins[coin.lower()]["addressType"]
+            xpub = self.get_hd_wallet_encode_seed(coin=coin.lower(), type=type)
+            derived_num = self.wallet_context.get_derived_num(xpub)
+        return derived_num
 
     def delete_devired_wallet_info(self, wallet_obj, hw=False):
         derivation = wallet_obj.get_derivation_path(wallet_obj.get_addresses()[0])
@@ -3566,7 +3583,8 @@ class AndroidCommands(commands.Commands):
             else:
                 xpub = wallet_obj.keystore.xpub + coin.lower()
         else:
-            xpub = self.get_hd_wallet_encode_seed(coin=coin)
+            purpose = helpers.get_path_info(wallet_obj.get_derivation_path(), PURPOSE_POS)
+            xpub = self.get_hd_wallet_encode_seed(coin=coin, type=purpose)
 
         self.wallet_context.remove_derived_wallet(xpub, account_id)
 

--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -2527,7 +2527,7 @@ class AndroidCommands(commands.Commands):
         :coin: btc/eth as string
         :return: xpub as string
         """
-        xpub = self.get_xpub_from_hw(path=path, _type="p2wpkh", coin=coin)
+        xpub = self.get_xpub_from_hw(path=path, _type=_type, coin=coin)
         self.hw_info["xpub"] = xpub
         if bip39_derivation is None:
             list_info = self.get_derived_list(xpub + coin.lower(), hw=True)
@@ -2915,7 +2915,7 @@ class AndroidCommands(commands.Commands):
             derive_key = self.get_hd_wallet_encode_seed(coin=coin, type=str(purpose))
             account_id = self._get_derived_account_id(derive_key)
         elif hw:
-            xpub = self.get_xpub_from_hw(path=path, coin=coin)
+            xpub = self.get_xpub_from_hw(path=path, coin=coin, _type=PURPOSE_TO_ADDRESS_TYPE.get(purpose, ""))
             account_id = self._get_derived_account_id(xpub + coin.lower(), hw=hw)
 
         if coin.lower() == 'btc':


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
commit1:BTC每种地址类型都可以派生20个钱包(软件支持)
commit2：BTC根据地址类型派生钱包（硬件支持）
commit3：根据review意见做了一些修复
commit4：解决新逻辑跟已创建钱包的兼容性问题

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
https://github.com/OneKeyHQ/TaskHub/issues/1253

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
Python

## Any other comments?
…
