### PR TITLE
Fixing an inaccurate amount displayed in eth wallet

### DIFF
--- a/electrum_gui/common/provider/chains/eth/clients/etherscan.py
+++ b/electrum_gui/common/provider/chains/eth/clients/etherscan.py
@@ -89,7 +89,7 @@ class Etherscan(ClientInterface, SearchTransactionMixin):
             status = TransactionStatus.CONFIRM_SUCCESS
 
         gas_limit = int(raw_tx["gas"], base=16)
-        gas_used = int(receipt["gasUsed"], 0) if receipt else None
+        gas_used = int(receipt["gasUsed"], base=16) if receipt else None
         gas_used = gas_used or gas_limit
         fee = TransactionFee(
             limit=gas_limit,
@@ -152,7 +152,7 @@ class Etherscan(ClientInterface, SearchTransactionMixin):
             fee = TransactionFee(limit=gas_limit, used=gas_used, price_per_unit=int(raw_tx["gasPrice"]))
             sender = raw_tx.get("from", "").lower()
             receiver = raw_tx.get("to", "").lower()
-            value = int(raw_tx.get("value", "0x0"), base=16)
+            value = int(raw_tx.get("value", "0"))
 
             tx = Transaction(
                 txid=raw_tx["hash"],
@@ -162,7 +162,7 @@ class Etherscan(ClientInterface, SearchTransactionMixin):
                 status=status,
                 fee=fee,
                 raw_tx=json.dumps(raw_tx),
-                nonce=int(raw_tx["nonce"], base=16),
+                nonce=int(raw_tx["nonce"]),
             )
             txs.append(tx)
 


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
commit1：
        现象：修复eth钱包显示金额不准确问题
        原因：因为etherscan获取到的金额是10进制，代码中却进行了16进制的转换

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
…

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
Python and Android

## Any other comments?
…
