### PR TITLE
Get the derivation path of the current wallet

### DIFF
--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -3540,6 +3540,21 @@ class AndroidCommands(commands.Commands):
             wallet.start_network(self.daemon.network)
         wallet.save_db()
 
+    def get_wallet_derivation_path(self, address: str) -> str:
+        """
+        Get the current wallet derivation path
+        :return: path as string
+        """
+        self._assert_wallet_isvalid()
+        derivation_path = self.wallet.get_derivation_path(address)
+        return json.dumps(
+            {
+                "coin": self.wallet.coin,
+                "path": derivation_path,
+                "type": helpers.get_path_info(derivation_path, PURPOSE_POS),
+            }
+        )
+
     def get_devired_num(self, coin="btc"):
         """
         Get devired HD num by app


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
前端需要展示当前钱包(地址)的派生路径

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
https://github.com/OneKeyHQ/TaskHub/issues/1287#issuecomment-823813772

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
python

## Any other comments?
…
