### PR TITLE
Rework of #708

### DIFF
--- a/electrum/eth_servers.json
+++ b/electrum/eth_servers.json
@@ -1,15 +1,9 @@
 {
   "eth": {
     "id": "eth",
-    "name": "Ethereum",
     "coinId": 60,
     "addressType": 44,
     "symbol": "ETH",
-    "decimals": 18,
-    "blockchain": "Ethereum",
-    "curve": "secp256k1",
-    "publicKeyType": "secp256k1Extended",
-    "derived_info": "",
     "Provider": [
       {"mainnet": "https://rpc.blkdb.cn/eth", "chainid": "1"},
       {"testnet": "https://ropsten.infura.io/v3/f001ce716b6e4a33a557f74df6fe8eff", "chainid": "3"},
@@ -19,15 +13,9 @@
   },
   "heco": {
     "id": "heco",
-    "name": "Huobi ECO Chain",
     "coinId": 60,
     "addressType": 44,
     "symbol": "HT",
-    "decimals": 18,
-    "blockchain": "Heco",
-    "curve": "secp256k1",
-    "publicKeyType": "secp256k1Extended",
-    "derived_info": "",
     "Provider": [
       {"mainnet": "https://rpc.blkdb.cn/heco", "chainid": "128"},
       {"testnet": "https://testnode.onekey.so/heco", "chainid": "128"}
@@ -36,15 +24,9 @@
   },
   "bsc": {
     "id": "bsc",
-    "name": "Binance Smart Chain",
     "coinId": 60,
     "addressType": 44,
     "symbol": "BNB",
-    "decimals": 18,
-    "blockchain": "Bsc",
-    "curve": "secp256k1",
-    "publicKeyType": "secp256k1Extended",
-    "derived_info": "",
     "Provider": [
       {"mainnet": "https://rpc.blkdb.cn/bsc", "chainid": "56"},
       {"testnet": "https://data-seed-prebsc-2-s1.binance.org:8545", "chainid": "97"}

--- a/electrum/eth_wallet.py
+++ b/electrum/eth_wallet.py
@@ -847,17 +847,13 @@ class Imported_Eth_Wallet(Simple_Eth_Wallet):
 
     @classmethod
     def _create_customer_wallet(cls, ks, config, coin):
-        def import_seed_to_address(pubkey: str):
-            addr = pywalib.PyWalib.web3.toChecksumAddress(pubkey.to_address())
-            wallet.db.add_imported_address(addr, {'pubkey': str(pubkey)})
-
         db = wallet_db.WalletDB("", manual_upgrades=False)
         db.put("keystore", ks.dump())
         wallet = cls(db, None, config=config)
         wallet.coin = coin
-        pubkey = ks.get_pubkey_from_master_xpub()
-        pubkey = eth_keys.keys.PublicKey.from_compressed_bytes(pubkey)
-        import_seed_to_address(pubkey)
+        pubkey = eth_keys.keys.PublicKey.from_compressed_bytes(ks.get_pubkey_from_master_xpub())
+        addr = eth_utils.to_checksum_address(pubkey.to_address())
+        wallet.db.add_imported_address(addr, {'pubkey': str(pubkey)})
         return wallet
 
     @classmethod

--- a/electrum/pywalib.py
+++ b/electrum/pywalib.py
@@ -7,7 +7,7 @@ import sqlite3
 from contextlib import contextmanager
 from decimal import Decimal
 from os.path import expanduser
-from typing import List, Optional
+from typing import Optional
 
 import requests
 import urllib3
@@ -590,7 +590,3 @@ class PyWalib:
             output_txs.append(output_tx)
 
         return output_txs
-
-    @classmethod
-    def get_all_txid(cls, address) -> List[str]:
-        return provider_manager.search_txids_by_address(cls.get_chain_code(), address)

--- a/electrum/pywalib.py
+++ b/electrum/pywalib.py
@@ -19,7 +19,6 @@ from web3 import HTTPProvider, Web3
 from electrum.util import make_aiohttp_session
 from electrum_gui.common.provider.data import (
     TransactionStatus,
-    Address,
     TxBroadcastReceiptCode,
 )
 from electrum_gui.common.provider import provider_manager
@@ -591,10 +590,6 @@ class PyWalib:
             output_txs.append(output_tx)
 
         return output_txs
-
-    @classmethod
-    def get_address(cls, address) -> Address:
-        return provider_manager.get_address(cls.get_chain_code(), address)
 
     @classmethod
     def get_all_txid(cls, address) -> List[str]:

--- a/electrum/pywalib.py
+++ b/electrum/pywalib.py
@@ -611,38 +611,3 @@ class PyWalib:
     @classmethod
     def get_all_txid(cls, address) -> List[str]:
         return provider_manager.search_txids_by_address(cls.get_chain_code(), address)
-
-    @classmethod
-    def get_transaction_info(cls, txid) -> dict:
-        tx = provider_manager.get_transaction_by_txid(cls.get_chain_code(), txid)
-        amount = Decimal(cls.web3.fromWei(tx.outputs[0].value, "ether"))
-        fee = Decimal(cls.web3.fromWei(tx.fee.used * tx.fee.price_per_unit, "ether"))
-
-        tx_status = _("Unconfirmed")
-        show_status = [1, _("Unconfirmed")]
-        if tx.status == TransactionStatus.CONFIRM_REVERTED:
-            tx_status = _("Sending failure")
-            show_status = [2, _("Sending failure")]
-        elif tx.status == TransactionStatus.CONFIRM_SUCCESS:
-            tx_status = (
-                _("{} confirmations").format(tx.block_header.confirmations)
-                if tx.block_header and tx.block_header.confirmations > 0
-                else _("Confirmed")
-            )
-            show_status = [3, _("Confirmed")]
-
-        return {
-            'txid': txid,
-            'can_broadcast': False,
-            'amount': amount,
-            'fee': fee,
-            'description': "",
-            'tx_status': tx_status,
-            "show_status": show_status,
-            'sign_status': None,
-            'output_addr': [tx.outputs[0].address],
-            'input_addr': [tx.inputs[0].address],
-            'height': tx.block_header.block_number if tx.block_header else -2,
-            'cosigner': [],
-            'tx': tx.raw_tx,
-        }

--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -73,6 +73,7 @@ from electrum.wallet import Imported_Wallet, Standard_Wallet, Wallet
 from electrum.wallet_db import WalletDB
 from electrum_gui.android import hardware, helpers, wallet_context
 from electrum_gui.common import the_begging
+from electrum_gui.common.provider import data as provider_data
 
 from ..common.basic.functional.text import force_text
 from ..common.basic.orm.database import db
@@ -1728,18 +1729,51 @@ class AndroidCommands(commands.Commands):
         return self.get_details_info(tx, tx_list=tx_list)
 
     def get_eth_tx_info(self, tx_hash) -> str:
-        tx = self.pywalib.get_transaction_info(tx_hash)
-
         chain_code = self._coin_to_chain_code(self.wallet.coin)
-        main_coin_price = price_manager.get_last_price(chain_code, self.ccy)
-        fiat = Decimal(tx["amount"]) * main_coin_price
-        fee_fiat = Decimal(tx["fee"]) * main_coin_price
-        symbol = coin_manager.get_coin_info(coin_manager.get_chain_info(chain_code).fee_code).symbol
+        fee_code = coin_manager.get_chain_info(chain_code).fee_code
+        symbol = coin_manager.get_coin_info(fee_code).symbol
 
-        tx["amount"] = f"{tx['amount']} {symbol} ({self.daemon.fx.ccy_amount_str(fiat, True)} {self.ccy})"
-        tx["fee"] = f"{tx['fee']} {symbol} ({self.daemon.fx.ccy_amount_str(fee_fiat, True)} {self.ccy})"
+        main_coin_price = price_manager.get_last_price(fee_code, self.ccy)
+        transaction = provider_manager.get_transaction_by_txid(chain_code, tx_hash)
 
-        return json.dumps(tx, cls=DecimalEncoder)
+        if transaction.status == provider_data.TransactionStatus.CONFIRM_REVERTED:
+            tx_status = _("Sending failure")
+            show_status = [2, _("Sending failure")]
+        elif transaction.status == provider_data.TransactionStatus.CONFIRM_SUCCESS:
+            tx_status = (
+                _("{} confirmations").format(transaction.block_header.confirmations)
+                if transaction.block_header and transaction.block_header.confirmations > 0
+                else _("Confirmed")
+            )
+            show_status = [3, _("Confirmed")]
+        else:
+            tx_status = _("Unconfirmed")
+            show_status = [1, _("Unconfirmed")]
+
+        amount = Decimal(eth_utils.from_wei(transaction.outputs[0].value, "ether"))
+        fee = Decimal(eth_utils.from_wei(transaction.fee.used * transaction.fee.price_per_unit, "ether"))
+        display_amount = (
+            f"{amount} {symbol} ({self.daemon.fx.ccy_amount_str(amount * main_coin_price, True)} {self.ccy})"
+        )
+        display_fee = f"{fee} {symbol} ({self.daemon.fx.ccy_amount_str(fee * main_coin_price, True)} {self.ccy})"
+
+        ret = {
+            "txid": tx_hash,
+            "can_broadcast": False,
+            "amount": display_amount,
+            "fee": display_fee,
+            "description": "",
+            'tx_status': tx_status,
+            "show_status": show_status,
+            'sign_status': None,
+            'output_addr': [transaction.outputs[0].address],
+            'input_addr': [transaction.inputs[0].address],
+            'height': transaction.block_header.block_number if transaction.block_header else -2,
+            'cosigner': [],
+            'tx': transaction.raw_tx,
+        }
+
+        return json.dumps(ret, cls=DecimalEncoder)
 
     def get_card(self, tx_hash, tx_mined_status, delta, fee, balance):
         try:

--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -992,9 +992,7 @@ class AndroidCommands(commands.Commands):
 
         for val in estimate_gas_prices.values():
             val["gas_limit"] = gas_limit
-            val["fee"] = self.pywalib.web3.fromWei(
-                gas_limit * self.pywalib.web3.toWei(val["gas_price"], "gwei"), "ether"
-            )
+            val["fee"] = eth_utils.from_wei(gas_limit * eth_utils.to_wei(val["gas_price"], "gwei"), "ether")
             val["fiat"] = f"{self.daemon.fx.ccy_amount_str(Decimal(val['fee']) * last_price, True)} {self.ccy}"
 
         return estimate_gas_prices
@@ -2375,10 +2373,8 @@ class AndroidCommands(commands.Commands):
 
         signed_tx_hex = self.sign_eth_tx(
             to_addr=transaction["to"],
-            value=self.pywalib.web3.fromWei(transaction["value"], "ether") if transaction.get("value") else 0,
-            gas_price=self.pywalib.web3.fromWei(transaction["gasPrice"], "gwei")
-            if transaction.get("gasPrice")
-            else None,
+            value=eth_utils.from_wei(transaction["value"], "ether") if transaction.get("value") else 0,
+            gas_price=eth_utils.from_wei(transaction["gasPrice"], "gwei") if transaction.get("gasPrice") else None,
             gas_limit=transaction.get("gas"),
             data=transaction.get("data"),
             nonce=transaction.get("nonce"),
@@ -2401,7 +2397,7 @@ class AndroidCommands(commands.Commands):
         else:
             message_bytes = message.encode()
 
-        return PyWalib.web3.keccak(message_bytes).hex()
+        return eth_utils.keccak(message_bytes).hex()
 
     def sign_tx(self, tx, path=None, password=None):
         """
@@ -3280,7 +3276,7 @@ class AndroidCommands(commands.Commands):
                             address_info = None
 
                         if address_info and address_info.existing:
-                            main_coin_balance = Decimal(self.pywalib.web3.fromWei(address_info.balance, "ether"))
+                            main_coin_balance = Decimal(eth_utils.from_wei(address_info.balance, "ether"))
                             fiat_price = price_manager.get_last_price(coin, self.ccy)
                             fiat_str = self.daemon.fx.ccy_amount_str(main_coin_balance * fiat_price, True)
                             balance = f"{main_coin_balance} ({fiat_str} {self.ccy})"

--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -1610,11 +1610,9 @@ class AndroidCommands(commands.Commands):
         for tx in txs:
             fiat = Decimal(tx["amount"]) * amount_coin_price
             fee_fiat = Decimal(tx["fee"]) * main_coin_price
+            fee_symbol = coin_manager.get_coin_info(coin_manager.get_chain_info(chain_code).fee_code).symbol
             tx["amount"] = f"{tx['amount']} {tx['coin']} ({self.daemon.fx.ccy_amount_str(fiat, True)} {self.ccy})"
-            tx["fee"] = (
-                f"{tx['fee']} {self.pywalib.coin_symbol} "
-                f"({self.daemon.fx.ccy_amount_str(fee_fiat, True)} {self.ccy})"
-            )
+            tx["fee"] = f"{tx['fee']} {fee_symbol} ({self.daemon.fx.ccy_amount_str(fee_fiat, True)} {self.ccy})"
 
         return json.dumps(txs, cls=DecimalEncoder)
 
@@ -1731,16 +1729,15 @@ class AndroidCommands(commands.Commands):
 
     def get_eth_tx_info(self, tx_hash) -> str:
         tx = self.pywalib.get_transaction_info(tx_hash)
-        main_coin_price = price_manager.get_last_price(self._coin_to_chain_code(self.wallet.coin), self.ccy)
+
+        chain_code = self._coin_to_chain_code(self.wallet.coin)
+        main_coin_price = price_manager.get_last_price(chain_code, self.ccy)
         fiat = Decimal(tx["amount"]) * main_coin_price
         fee_fiat = Decimal(tx["fee"]) * main_coin_price
+        symbol = coin_manager.get_coin_info(coin_manager.get_chain_info(chain_code).fee_code).symbol
 
-        tx[
-            "amount"
-        ] = f"{tx['amount']} {self.pywalib.coin_symbol} ({self.daemon.fx.ccy_amount_str(fiat, True)} {self.ccy})"
-        tx[
-            "fee"
-        ] = f"{tx['fee']} {self.pywalib.coin_symbol} ({self.daemon.fx.ccy_amount_str(fee_fiat, True)} {self.ccy})"
+        tx["amount"] = f"{tx['amount']} {symbol} ({self.daemon.fx.ccy_amount_str(fiat, True)} {self.ccy})"
+        tx["fee"] = f"{tx['fee']} {symbol} ({self.daemon.fx.ccy_amount_str(fee_fiat, True)} {self.ccy})"
 
         return json.dumps(tx, cls=DecimalEncoder)
 

--- a/electrum_gui/common/provider/chains/eth/clients/blockbook.py
+++ b/electrum_gui/common/provider/chains/eth/clients/blockbook.py
@@ -15,7 +15,6 @@ from electrum_gui.common.provider.data import (
     ClientInfo,
     EstimatedTimeOnPrice,
     PricePerUnit,
-    Token,
     Transaction,
     TransactionFee,
     TransactionInput,
@@ -84,8 +83,8 @@ class BlockBook(ClientInterface, SearchTransactionMixin):
         require(resp["address"].lower() == address.lower())
         return resp
 
-    def get_balance(self, address: str, token: Token = None) -> int:
-        if not token:
+    def get_balance(self, address: str, token_address: Optional[str] = None) -> int:
+        if token_address is None:
             return super(BlockBook, self).get_balance(address)
         else:
             resp = self._get_raw_address_info(address, details="tokenBalances")
@@ -94,7 +93,7 @@ class BlockBook(ClientInterface, SearchTransactionMixin):
                 for token_dict in (resp.get("tokens") or ())
                 if token_dict.get("contract") and token_dict.get("balance")
             }
-            balance = tokens.get(token.contract.lower(), 0)
+            balance = tokens.get(token_address.lower(), 0)
             return int(balance)
 
     def get_transaction_by_txid(self, txid: str) -> Transaction:

--- a/electrum_gui/common/provider/chains/eth/clients/etherscan.py
+++ b/electrum_gui/common/provider/chains/eth/clients/etherscan.py
@@ -9,7 +9,6 @@ from electrum_gui.common.provider.data import (
     ClientInfo,
     EstimatedTimeOnPrice,
     PricePerUnit,
-    Token,
     Transaction,
     TransactionFee,
     TransactionInput,
@@ -55,11 +54,11 @@ class Etherscan(ClientInterface, SearchTransactionMixin):
         nonce = int(resp["result"], base=16)
         return Address(address=address, balance=balance, nonce=nonce, existing=(bool(balance) or bool(nonce)))
 
-    def get_balance(self, address: str, token: Token = None) -> int:
-        if not token:
+    def get_balance(self, address: str, token_address: Optional[str] = None) -> int:
+        if token_address is None:
             return super(Etherscan, self).get_balance(address)
         else:
-            resp = self._call_action("account", "tokenbalance", address=address, contractaddress=token.contract)
+            resp = self._call_action("account", "tokenbalance", address=address, contractaddress=token_address)
             return int(resp.get("result", 0))
 
     def get_transaction_by_txid(self, txid: str) -> Transaction:

--- a/electrum_gui/common/provider/chains/eth/clients/geth.py
+++ b/electrum_gui/common/provider/chains/eth/clients/geth.py
@@ -1,6 +1,6 @@
 import time
 from functools import partial
-from typing import Any
+from typing import Any, Optional
 
 import eth_utils
 
@@ -14,7 +14,6 @@ from electrum_gui.common.provider.data import (
     ClientInfo,
     EstimatedTimeOnPrice,
     PricePerUnit,
-    Token,
     Transaction,
     TransactionFee,
     TransactionInput,
@@ -54,14 +53,14 @@ class Geth(ClientInterface):
         nonce = _hex2int(_nonce)
         return Address(address=address, balance=balance, nonce=nonce, existing=(bool(balance) or bool(nonce)))
 
-    def get_balance(self, address: str, token: Token = None) -> int:
-        if not token:
+    def get_balance(self, address: str, token_address: Optional[str] = None) -> int:
+        if token_address is None:
             return super(Geth, self).get_balance(address)
         else:
             call_balance_of = (
                 "0x70a08231000000000000000000000000" + address[2:]
             )  # method_selector(balance_of) + byte32_pad(address)
-            resp = self.eth_call({"to": token.contract, "data": call_balance_of})
+            resp = self.eth_call({"to": token_address, "data": call_balance_of})
 
             try:
                 return _hex2int(resp[:66])

--- a/electrum_gui/common/provider/data.py
+++ b/electrum_gui/common/provider/data.py
@@ -99,11 +99,6 @@ class Address(DataClassMixin):
 
 
 @dataclass
-class Token(DataClassMixin):
-    contract: str
-
-
-@dataclass
 class TxBroadcastReceipt(DataClassMixin):
     is_success: bool
     receipt_code: TxBroadcastReceiptCode

--- a/electrum_gui/common/provider/interfaces.py
+++ b/electrum_gui/common/provider/interfaces.py
@@ -9,7 +9,6 @@ from electrum_gui.common.provider.data import (
     ClientInfo,
     PricePerUnit,
     SignedTx,
-    Token,
     Transaction,
     TransactionStatus,
     TxBroadcastReceipt,
@@ -44,7 +43,7 @@ class ClientInterface(ABC):
         :return: Address
         """
 
-    def get_balance(self, address: str, token: Token = None) -> int:
+    def get_balance(self, address: str, contract_address: Optional[str] = None) -> int:
         """
         get address balance
         :param address: address

--- a/electrum_gui/common/provider/manager.py
+++ b/electrum_gui/common/provider/manager.py
@@ -6,7 +6,6 @@ from electrum_gui.common.provider.data import (
     AddressValidation,
     PricePerUnit,
     SignedTx,
-    Token,
     Transaction,
     TransactionStatus,
     TxBroadcastReceipt,
@@ -23,8 +22,10 @@ def get_address(chain_code: str, address: str) -> Address:
     return get_client_by_chain(chain_code).get_address(address)
 
 
-def get_balance(chain_code: str, address: str, token: Token = None) -> int:
-    return get_client_by_chain(chain_code).get_balance(address, token=token)
+def get_balance(chain_code: str, address: str, token_address: Optional[str] = None) -> int:
+    # TODO: raise specific exceptions for callers to catch. This also applies
+    # to the APIs in this module.
+    return get_client_by_chain(chain_code).get_balance(address, token_address=token_address)
 
 
 def get_transaction_by_txid(chain_code: str, txid: str) -> Transaction:


### PR DESCRIPTION
#708 合并之后我们又合并了 #725，但是 #708 合并得不是时候，所以这两个PR都回滚掉然后重新提交了 #727 作为 #725 的替代先合并进去。现在重新提交一次 #708 中的内容。

与 #725 合并之后的代码diff结果如下（改了一处变量名，#727 比 #725 多了一处小改动），所以整体代码仍一致
```diff
$ git diff 8f5370cde94fce918fbf6a966da1c55b84ad8aa4
diff --git a/electrum_gui/android/console.py b/electrum_gui/android/console.py
index e55383c33..09c6d8e93 100755
--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -1060,7 +1060,7 @@ class AndroidCommands(commands.Commands):
         except Exception as e:
             raise BaseException(e)
 
-        ret_data = {"tx": str(self.tx)}
+        ret_data = {"tx": str(tx)}
         try:
             if self.label_flag and self.wallet.wallet_type != "standard":
                 self.label_plugin.push_tx(self.wallet, "createtx", tx.txid(), str(self.tx))
@@ -4235,18 +4235,14 @@ class AndroidCommands(commands.Commands):
             try:
                 address_info = provider_manager.get_address(chain_code, wallet_obj.get_addresses()[0])
             except Exception:
-                address_info = None
-
-            if address_info is not None:
-                history = address_info.existing
-            else:
                 return
+            wallet_has_history = address_info.existing
         elif coin == "btc":
-            history = wallet_obj.get_history()
+            wallet_has_history = bool(wallet_obj.get_history())
         else:
             return
 
-        if history:
+        if wallet_has_history:
             return
 
         # delete wallet info from config
```