### PR TITLE
add batch to get address info feature

### DIFF
--- a/electrum_gui/common/provider/interfaces.py
+++ b/electrum_gui/common/provider/interfaces.py
@@ -96,6 +96,16 @@ class ClientInterface(ABC):
         raise Exception("Unsupported")
 
 
+class BatchGetAddressMixin(ABC):
+    @abstractmethod
+    def batch_get_address(self, addresses: List[str]) -> List[Address]:
+        """
+        Batch to get address information by address str list
+        :param addresses: List[address]
+        :return: List[Address]
+        """
+
+
 class SearchTransactionMixin(ABC):
     def search_txs_by_address(  # noqa
         self,

--- a/electrum_gui/common/provider/manager.py
+++ b/electrum_gui/common/provider/manager.py
@@ -1,5 +1,6 @@
 from typing import Dict, List, Optional
 
+from electrum_gui.common.provider import exceptions
 from electrum_gui.common.provider.data import (
     UTXO,
     Address,
@@ -13,13 +14,22 @@ from electrum_gui.common.provider.data import (
     UnsignedTx,
 )
 from electrum_gui.common.provider.exceptions import NoAvailableClient
-from electrum_gui.common.provider.interfaces import SearchTransactionMixin, SearchUTXOMixin
+from electrum_gui.common.provider.interfaces import BatchGetAddressMixin, SearchTransactionMixin, SearchUTXOMixin
 from electrum_gui.common.provider.loader import get_client_by_chain, get_provider_by_chain
 from electrum_gui.common.secret.interfaces import SignerInterface, VerifierInterface
 
 
 def get_address(chain_code: str, address: str) -> Address:
     return get_client_by_chain(chain_code).get_address(address)
+
+
+def batch_get_address(chain_code: str, addresses: List[str]) -> List[Address]:
+    try:
+        client = get_client_by_chain(chain_code, instance_required=BatchGetAddressMixin)
+        return client.batch_get_address(addresses)
+    except exceptions.NoAvailableClient:
+        client = get_client_by_chain(chain_code)
+        return [client.get_address(i) for i in addresses]
 
 
 def get_balance(chain_code: str, address: str, token_address: Optional[str] = None) -> int:


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
 #恢复钱包，耗时分两步，推导 BTC 地址（大概10-20s），eth 和 eth fork 币种通过网络请求获取币种信息(80个网络请求，每个30S超时，可能会耗费45分钟时间才会返回结果)。

改进后，只会产生4个网络请求，每个设置10s超时，最坏情况，40s 能得到结果。

## Does this close any currently open issues?  
https://github.com/OneKeyHQ/TaskHub/issues/802

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
… python console

## Any other comments?
…
