### PR TITLE
console: fix wallet type when recovering wallets

### DIFF
--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -3582,8 +3582,8 @@ class AndroidCommands(commands.Commands):
         )
         db.put("keystore", ks.dump())
         if coin in self.coins:
+            db.put("wallet_type", f"{coin}_standard")
             wallet = Standard_Eth_Wallet(db, storage, config=self.config, index=account_id)
-            wallet.wallet_type = "%s_standard" % coin
         else:
             wallet = Standard_Wallet(db, storage, config=self.config)
         wallet.hide_type = True


### PR DESCRIPTION
In wallet db of a recovered EVM network based wallet, the wallet_type
was always "eth_standard". This is incorrect so this commit fixes it.

## What does this implement/fix? Explain your changes.
修复恢复钱包时wallet_type没有正确写入数据库导致后续的问题。

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
OneKeyHQ/TaskHub#1424

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
Android手打测试包

## Any other comments?
No
