### PR TITLE
Fix - use checksum address in web3

### DIFF
--- a/electrum/eth_wallet.py
+++ b/electrum/eth_wallet.py
@@ -469,7 +469,7 @@ class Abstract_Eth_Wallet(abc.ABC):
             "nonce": args[1],
             "gasPrice": args[2],
             "gas": args[3],
-            "to": args[4],
+            "to":  eth_utils.to_checksum_address(args[4]),
             "value": args[5],
             "chainId": kwargs["chain_id"],
         }


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
serializable_unsigned_transaction_from_dict 内部需要 to address 是 checksum address

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
…

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
…

## Any other comments?
…
