### PR TITLE
Fix recovery issue

### DIFF
--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -3600,6 +3600,7 @@ class AndroidCommands(commands.Commands):
         self, password=None, seed=None, passphrase="", xpub=None, hw=False, path="bluetooth"
     ):
         eths_xpub = None
+        self.recovery_wallets = {}
 
         def recovery_wallet(self, purpose: int, coin: str = "btc") -> None:
             def recovery_create_subfun(self, coin, account_id, name) -> None:

--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -3735,7 +3735,7 @@ class AndroidCommands(commands.Commands):
             db.put("wallet_type", f"{coin}_standard")
             wallet = Standard_Eth_Wallet(db, storage, config=self.config, index=account_id)
         elif chain_affinity == "btc":
-            ks = keystore.from_bip39_seed(seed, passphrase, util.get_keystore_path(bip39_derivation))
+            ks = keystore.from_bip39_seed(seed, passphrase, bip39_derivation)
             db.put("keystore", ks.dump())
             wallet = Standard_Wallet(db, storage, config=self.config)
         else:


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
commit1：恢复时，btc的path是不对的，导致创建的地址也是不对的
commit2：.恢复的时候清除上一次恢复的数据（之前的产品设计是有个取消恢复按钮，点击取消恢复会调用recovery_comfirmed并传入空list 此时进行清除缓存，后来取消按钮删除后修改为左上角返回按钮 此时 客户端没有调用此接口，就出现当用户恢复了一个助记词 但是没有确认创建 而是 返回 又重新输入一个新的助记词 就会有问题） 

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
https://github.com/OneKeyHQ/TaskHub/issues/1539
https://github.com/OneKeyHQ/TaskHub/issues/1526
https://github.com/OneKeyHQ/TaskHub/issues/1524

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
python

## Any other comments?
…
