### PR TITLE
Get token prices from Uniswap-based decentralized exchanges

### DIFF
--- a/electrum_gui/common/basic/request/interfaces.py
+++ b/electrum_gui/common/basic/request/interfaces.py
@@ -89,6 +89,7 @@ class JsonRPCInterface(ABC):
     def batch_call(
         self,
         calls: List[Tuple[str, Union[list, dict]]],
+        ignore_errors: bool = False,
         headers: dict = None,
         timeout: int = None,
         path: str = "",
@@ -97,6 +98,7 @@ class JsonRPCInterface(ABC):
         """
         Batch call to server
         :param calls: Batch calls group
+        :param ignore_errors: whether to ignore errors and return None instead of raising exceptions
         :param headers: request headers, optional
         :param timeout: request timeout, optional
         :param path: target path, optional

--- a/electrum_gui/common/coin/configs/chains.json
+++ b/electrum_gui/common/coin/configs/chains.json
@@ -74,6 +74,18 @@
         ]
       }
     ],
+    "dexes": {
+        "ImplUniswapCompatible": {
+            "router_address": "0x7a250d5630b4cf539739df2c5dacb4c659f2488d",
+            "base_token_address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "media_token_addresses": [
+                "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+                "0xdac17f958d2ee523a2206206994597c13d831ec7",
+                "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "0x6b175474e89094c44da98b954eedeac495271d0f"
+            ]
+        }
+    },
     "chain_affinity": "eth",
     "qr_code_prefix": "ethereum",
     "chain_id": "1"
@@ -120,6 +132,20 @@
         ]
       }
     ],
+    "dexes": {
+        "ImplUniswapCompatible": {
+            "router_address": "0x05ff2b0db69458a0750badebc4f9e13add608c7f",
+            "base_token_address": "0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c",
+            "media_token_addresses": [
+                "0x2170ed0880ac9a755fd29b2688956bd959f933f8",
+                "0x55d398326f99059ff775485246999027b3197955",
+                "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d",
+                "0xe9e7cea3dedca5984780bafc599bd69add087d56",
+                "0x1af3f329e8be154074d8769d1ffa4ee058b1dbc3",
+                "0x7130d2a12b9bcbfae4f2634d864a1ee1ce3ead9c"
+            ]
+        }
+    },
     "chain_affinity": "eth",
     "qr_code_prefix": "bsc",
     "chain_id": "56"
@@ -166,6 +192,20 @@
         ]
       }
     ],
+    "dexes": {
+        "ImplUniswapCompatible": {
+            "router_address": "0xed7d5f38c79115ca12fe6c0041abb22f0a06c300",
+            "base_token_address": "0x5545153ccfca01fbd7dd11c0b23ba694d9509a6f",
+            "media_token_addresses": [
+                "0x66a79d23e58475d2738179ca52cd0b41d73f0bea",
+                "0x64ff637fb478863b7468bc97d30a5bf3a428a1fd",
+                "0xa71edc38d189767582c38a3145b5873052c3e47a",
+                "0x0298c2b32eae4da002a15f36fdf7615bea3da047",
+                "0x25d2e80cb6b86881fd7e07dd263fb79f4abe033c",
+                "0x9362bbef4b8313a8aa9f0c9808b80577aa26b73b"
+            ]
+        }
+    },
     "chain_affinity": "eth",
     "qr_code_prefix": "heco",
     "chain_id": "128"

--- a/electrum_gui/common/coin/data.py
+++ b/electrum_gui/common/coin/data.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from enum import IntEnum, unique
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from electrum_gui.common.basic.dataclass.dataclass import DataClassMixin
 from electrum_gui.common.secret.data import CurveEnum
@@ -31,6 +31,7 @@ class ChainInfo(DataClassMixin):
     )
     default_address_encoding: Optional[str] = None
     clients: List[dict] = field(default_factory=list)  # config of clients
+    dexes: Dict[str, dict] = field(default_factory=dict)  # config of decentralized exchanges
     chain_id: Optional[str] = None  # optional, identify multi forked chains by chain_id (use by eth etc.)
     bip44_purpose_options: dict = field(default_factory=dict)
     fee_price_decimals_for_legibility: int = 0  # (gwei in eth etc.)

--- a/electrum_gui/common/price/channels/uniswap.py
+++ b/electrum_gui/common/price/channels/uniswap.py
@@ -1,0 +1,110 @@
+import decimal
+import itertools
+import operator
+from typing import Iterable, List, Tuple
+
+import eth_abi
+
+from electrum_gui.common.coin import data as coin_data
+from electrum_gui.common.coin import manager as coin_manager
+from electrum_gui.common.price import data, interfaces
+from electrum_gui.common.provider import manager as provider_manager
+from electrum_gui.common.provider.chains.eth.clients import geth as geth_client
+
+BATCH_SIZE = 50
+
+# Refer to https://uniswap.org/docs/v2/smart-contracts/router02
+
+
+def _get_eth_call_data(coin: coin_data.CoinInfo, paths: Tuple[Tuple]) -> List[str]:
+    # >>> eth_utils.keccak("getAmountsOut(uint256,address[])".encode())[:4].hex()
+    # 'd06ca61f'
+    return [
+        "0xd06ca61f"
+        + eth_abi.encode_single("(uint256,address[])", (10 ** coin.decimals, [coin.token_address, *path])).hex()
+        for path in paths
+    ]
+
+
+def _extract_price_from_resp(resp: str) -> int:
+    # We want the last number only.
+    return eth_abi.decode_single("uint256", bytes.fromhex(resp[2:])[-32:])
+
+
+def _obtain_prices_from_dex(
+    chain: coin_data.ChainInfo,
+    router_address: str,
+    base_divisor: int,
+    coins: List[Tuple[coin_data.CoinInfo, int]],
+    call_data: List[str],
+) -> Iterable[data.YieldedPrice]:
+    client = provider_manager.get_client_by_chain(chain.chain_code, instance_required=geth_client.Geth)
+
+    resp_iterator = iter(client.call_contract(router_address, call_data))
+    for coin, paths_count in coins:
+        price = (
+            decimal.Decimal(
+                max(
+                    _extract_price_from_resp(resp) if resp is not None else 0
+                    for resp in itertools.islice(resp_iterator, paths_count)
+                )
+            )
+            / base_divisor
+        )
+        if price > 0:
+            yield data.YieldedPrice(coin_code=coin.code, unit=chain.chain_code, price=price)
+
+    yield from tuple()
+
+
+class Uniswap(interfaces.PriceChannelInterface):
+    def pricing(self, coins: Iterable[coin_data.CoinInfo]) -> Iterable[data.YieldedPrice]:
+        coins = sorted(coins, key=operator.attrgetter("chain_code"))
+        for chain_code, coins_on_chain in itertools.groupby(coins, operator.attrgetter("chain_code")):
+            chain = coin_manager.get_chain_info(chain_code)
+
+            uniswap_config = chain.dexes.get("ImplUniswapCompatible")
+            if uniswap_config is None:
+                continue
+
+            router_address = uniswap_config["router_address"]
+            base_token_address = uniswap_config["base_token_address"]
+            media_token_addresses = tuple(uniswap_config["media_token_addresses"])
+            paths_for_media_tokens = ((base_token_address,),)  # Direct exchange
+            paths_for_normal_tokens = paths_for_media_tokens + tuple(
+                itertools.product(media_token_addresses, [base_token_address])
+            )
+
+            base_coin = coin_manager.get_coin_info(chain.chain_code)
+            base_divisor = 10 ** base_coin.decimals
+
+            total_paths_count = 0
+            coins_in_one_request = []
+            data_in_one_request = []
+            for coin in coins_on_chain:
+                if coin.token_address is None:  # Not a token
+                    continue
+                elif coin.token_address == base_token_address:  # It's a base token, i.e., a WETH/WBNB/WHT...
+                    yield data.YieldedPrice(coin_code=coin.code, unit=base_coin.code, price=decimal.Decimal("1"))
+                    continue
+                elif coin.token_address in media_token_addresses:  # A media token
+                    paths = paths_for_media_tokens
+                else:
+                    paths = paths_for_normal_tokens
+
+                paths_count_of_this_coin = len(paths)
+                coins_in_one_request.append((coin, paths_count_of_this_coin))
+                data_in_one_request.extend(_get_eth_call_data(coin, paths))
+
+                total_paths_count += paths_count_of_this_coin
+                if total_paths_count >= BATCH_SIZE:
+                    yield from _obtain_prices_from_dex(
+                        chain, router_address, base_divisor, coins_in_one_request, data_in_one_request
+                    )
+                    total_paths_count = 0
+                    coins_in_one_request = []
+                    data_in_one_request = []
+
+            yield from _obtain_prices_from_dex(
+                chain, router_address, base_divisor, coins_in_one_request, data_in_one_request
+            )

--- a/electrum_gui/common/price/data.py
+++ b/electrum_gui/common/price/data.py
@@ -5,6 +5,7 @@ from enum import IntEnum, unique
 @unique
 class Channel(IntEnum):
     CGK = 10
+    UNISWAP = 20
 
     @classmethod
     def to_choices(cls):

--- a/electrum_gui/common/price/manager.py
+++ b/electrum_gui/common/price/manager.py
@@ -10,14 +10,15 @@ from electrum_gui.common.coin import codes
 from electrum_gui.common.coin import manager as coin_manager
 from electrum_gui.common.conf import settings
 from electrum_gui.common.price import daos
-from electrum_gui.common.price.channels.coingecko import Coingecko
+from electrum_gui.common.price.channels import coingecko, uniswap
 from electrum_gui.common.price.data import Channel
 from electrum_gui.common.price.interfaces import PriceChannelInterface
 
 logger = logging.getLogger("app.price")
 
 _registry: Dict[Channel, Callable[[], PriceChannelInterface]] = {
-    Channel.CGK: functools.partial(Coingecko, settings.COINGECKO_API_HOST),
+    Channel.CGK: functools.partial(coingecko.Coingecko, settings.COINGECKO_API_HOST),
+    Channel.UNISWAP: uniswap.Uniswap,
 }
 
 


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
从去中心化交易所获取代币价格，目前添加Uniswap Router合约的支持，从而支持ETH(使用Uniswap)、BSC(使用pancake)，HECO(使用mdex)链上的代币价格获取。

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
OneKeyHQ/TaskHub#1487

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
Android Mainnet App

## Any other comments?
- 合约地址和相关中间代币地址以及基础代币(WETH/WBNB/WHT)地址都在配置文件里，因为考虑后面转成动态
- json不好写注释所以没法在文件中直接注明合约地址对应的代币，可能以后考虑用yaml...