### PR TITLE
fix eth fee calculation

### DIFF
--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -5,6 +5,7 @@ import copy
 import itertools
 import json
 import logging
+import math
 import os
 import random
 import string
@@ -1049,8 +1050,8 @@ class AndroidCommands(commands.Commands):
         last_price = price_manager.get_last_price(main_coin_code, self.ccy)
         estimated_gas_prices = {}
         for description, estimated_gas_price in provider_manager.get_prices_per_unit_of_fee(chain_code):
-            fee = eth_utils.from_wei(gas_limit * estimated_gas_price.price, "ether")
-            price = int(eth_utils.from_wei(estimated_gas_price.price, "gwei"))
+            price = math.ceil(eth_utils.from_wei(estimated_gas_price.price, "gwei"))
+            fee = eth_utils.from_wei(gas_limit * eth_utils.to_wei(price, "gwei"), "ether")
             gas_price_info = {
                 "gas_price": price,
                 "time": Decimal(estimated_gas_price.time) / 60,


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
eth fee 计算有误差，需要确保 gas_price * gas_limit = fee

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
https://github.com/OneKeyHQ/TaskHub/issues/1564

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
…

## Any other comments?
…
