### PR TITLE
【WIF】The unique value of the evm chain wallet is modified to coin+address.lower()

### DIFF
--- a/electrum/eth_wallet.py
+++ b/electrum/eth_wallet.py
@@ -149,7 +149,7 @@ class Abstract_Eth_Wallet(abc.ABC):
         if self._identity is None:
             prefix = self.coin if self.coin != "eth" else ""
             # crypto.sha256 returns a bytes object
-            self._identity = crypto.sha256(prefix + self.get_addresses()[0]).hex()
+            self._identity = crypto.sha256(prefix + (self.get_addresses()[0]).lower()).hex()
         return self._identity
 
     @property


### PR DESCRIPTION

## What does this implement/fix? Explain your changes.
修复eth类钱包 导入checksum地址和全小写地址全都可以创建钱包的问题

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
https://github.com/OneKeyHQ/TaskHub/issues/1666

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
python

## Any other comments?
…
