### PR TITLE
Modify the tx_status field in the get_all_tx_list return value

### DIFF
--- a/electrum_gui/common/provider/data.py
+++ b/electrum_gui/common/provider/data.py
@@ -10,9 +10,9 @@ from electrum_gui.common.basic.dataclass.dataclass import DataClassMixin
 @unique
 class TransactionStatus(IntEnum):
     UNKNOWN = 0
-    PENDING = 10
-    CONFIRM_REVERTED = 99
-    CONFIRM_SUCCESS = 100
+    PENDING = 1
+    CONFIRM_REVERTED = 2
+    CONFIRM_SUCCESS = 3
 
 
 @unique
@@ -86,23 +86,23 @@ class Transaction(DataClassMixin):
     @property
     def detailed_status(self) -> str:
         if self.status == TransactionStatus.CONFIRM_REVERTED:
-            return "Sending failure"
+            return {"status": TransactionStatus.CONFIRM_REVERTED, "other_info": ""}
         elif self.status == TransactionStatus.CONFIRM_SUCCESS:
             if self.block_header is not None and self.block_header.confirmations > 0:
-                return ("{} confirmations").format(self.block_header.confirmations)
+                return {"status": TransactionStatus.CONFIRM_SUCCESS, "other_info": str(self.block_header.confirmations)}
             else:
-                return "Confirmed"
+                return {"status": TransactionStatus.CONFIRM_SUCCESS, "other_info": ""}
         else:
-            return "Unconfirmed"
+            return {"status": TransactionStatus.PENDING, "other_info": ""}
 
     @property
     def show_status(self) -> List:
         if self.status == TransactionStatus.CONFIRM_REVERTED:
-            return [2, i18n._("Sending failure")]
+            return [TransactionStatus.CONFIRM_REVERTED, i18n._("Sending failure")]
         elif self.status == TransactionStatus.CONFIRM_SUCCESS:
-            return [3, i18n._("Confirmed")]
+            return [TransactionStatus.CONFIRM_SUCCESS, i18n._("Confirmed")]
         else:
-            return [1, i18n._("Unconfirmed")]
+            return [TransactionStatus.PENDING, i18n._("Unconfirmed")]
 
     @property
     def date_str(self) -> str:


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
跟前端讨论后 获取交易历史中的tx_status字段以dict的方式返回 类似{“status”：2， “other_info:”}

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
…

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
…

## Any other comments?
…
