### PR TITLE
Solve the problem of failing to get the default fee information under etherscan

### DIFF
--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -915,6 +915,7 @@ class AndroidCommands(commands.Commands):
         }
         return ret_data
 
+    @exceptions.catch_exception
     def get_default_fee_info(self, feerate=None, coin="btc", eth_tx_info=None):
         """
         Get default fee info for btc

--- a/electrum_gui/common/provider/chains/eth/clients/etherscan.py
+++ b/electrum_gui/common/provider/chains/eth/clients/etherscan.py
@@ -1,3 +1,4 @@
+import decimal
 import json
 from typing import List, Optional
 
@@ -191,9 +192,9 @@ class Etherscan(ClientInterface, SearchTransactionMixin):
         if result is None:
             raise FailedToGetGasPrices()
 
-        slow = int(result["SafeGasPrice"] * 1e9)
-        normal = int(result["ProposeGasPrice"] * 1e9)
-        fast = int(result["FastGasPrice"] * 1e9)
+        slow = int(decimal.Decimal(result["SafeGasPrice"]) * 10 ** 9)
+        normal = int(decimal.Decimal(result["ProposeGasPrice"]) * 10 ** 9)
+        fast = int(decimal.Decimal(result["FastGasPrice"]) * 10 ** 9)
 
         return PricesPerUnit(
             fast=EstimatedTimeOnPrice(price=fast, time=60),


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
etherscan下发币失败问题：因为获取fee的时候转换报错

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
https://github.com/OneKeyHQ/TaskHub/issues/1736

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
python

## Any other comments?
…
