### PR TITLE
Recover the return value of the get_default_fee_info interface

### DIFF
--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -925,7 +925,6 @@ class AndroidCommands(commands.Commands):
         }
         return ret_data
 
-    @exceptions.catch_exception
     def get_default_fee_info(self, feerate=None, coin="btc", eth_tx_info=None):
         """
         Get default fee info for btc


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
回退get_default_fee_info的异常统一 （问题引入在https://github.com/OneKeyHQ/electrum/pull/779）

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.


## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
…

## Any other comments?
…
