### PR TITLE
Fix wallet_type error

### DIFF
--- a/electrum_gui/android/wallet_context.py
+++ b/electrum_gui/android/wallet_context.py
@@ -144,8 +144,6 @@ class WalletContext(object):
         self, generic_wallet_type: Optional[str] = None, coin: Optional[str] = None
     ) -> List[Tuple[str, str]]:
 
-        unknowns = []
-
         stored_wallets = self.stored_wallets
         extra_filter_func = _type_info_default_extra_filter_func
         sort_func = _type_info_default_sort_func
@@ -165,9 +163,6 @@ class WalletContext(object):
             extra_filter_func = functools.partial(_type_info_filter_wallet_type_by_coin, coin)
             sort_func = _type_info_by_type_and_time_sort_func
             order_info = dict(zip(self.get_wallet_location_info(coin), itertools.count()))
-        else:
-            # We want all stored wallets.
-            unknowns = list(zip(stored_wallets - set(self._type_info.keys()), itertools.repeat('unknow')))
 
         saved_wallets = {}
         for wallet_id, type_info in self._type_info.items():
@@ -178,7 +173,7 @@ class WalletContext(object):
 
         saved = [kv for kv in sorted(saved_wallets.items(), key=sort_func, reverse=True)]
         saved = [(kv[0], kv[1]['type']) for kv in sorted(saved, key=_type_info_by_customised_sort_func)]
-        return unknowns + saved
+        return saved
 
     def set_wallet_type(self, wallet_id: str, wallet_type: str) -> None:
         self._type_info[wallet_id] = {'type': wallet_type, 'time': time.time()}


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
上周五公司有部手机复现了wallet_type这个错误 就借机修复了 具体原因是由于本地存在一个.tmp.文件 并且这个文件的类型是unknown
我解决这个问题修改了两个地方：
        第一个是load_wallet使用的时候 如果解析异常就会直接return（不会添加到self.deamon中）
        第二个是list_wallets的时候不返回这类钱包信息

这个修复相当于是workaround，具体的原因还要查找为啥会出现.tmp.文件 这个会再继续跟踪  

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
…

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
iOS

## Any other comments?
…
