### PR TITLE
The definition of key on the python is not consistent with the definition of lokalise

### DIFF
--- a/electrum_gui/common/basic/exceptions.py
+++ b/electrum_gui/common/basic/exceptions.py
@@ -19,36 +19,36 @@ class ApiVersion(IntEnum):
 
 
 class OneKeyException(Exception):
-    key = "msg_unknown_error"
+    key = "msg__unknown_error"
     status = ResultStatus.FAILED
 
 
 class UnavailablePrivateKey(OneKeyException):
-    key = "msg_incorrect_private_key"
+    key = "msg__incorrect_private_key"
 
 
 class InvalidKeystoreFormat(OneKeyException):
-    key = "msg_incorrect_keystore_format"
+    key = "msg__incorrect_keystore_format"
 
 
 class InvalidMnemonicFormat(OneKeyException):
-    key = "msg_incorrect_recovery_phrase_format"
+    key = "msg__incorrect_recovery_phrase_format"
 
 
 class UnavailableBtcAddr(OneKeyException):
-    key = "msg_incorrect_bitcoin_address"
+    key = "msg__incorrect_bitcoin_address"
 
 
 class InvalidPassword(OneKeyException):
-    key = "msg_incorrect_password"
+    key = "msg__incorrect_password"
 
 
 class UnavailablePublicKey(OneKeyException):
-    key = "msg_incorrect_public_key"
+    key = "msg__incorrect_public_key"
 
 
 class UnavailableEthAddr(OneKeyException):
-    key = "msg_incorrect_eth_address"
+    key = "msg__incorrect_eth_address"
 
 
 def catch_exception(force_api_version: int = None):


### PR DESCRIPTION

## What does this implement/fix? Explain your changes.
python端使用的key(以msg_开头) 跟lokalise端定义的key不一致(以msg__开头) 导致前端解析不到正确翻译信息

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
https://github.com/OneKeyHQ/TaskHub/issues/1868


## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
…

## Any other comments?
…
