### PR TITLE
fix: adjust the calculation of coin_assets

### DIFF
--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -327,14 +327,24 @@ class AndroidCommands(commands.Commands):
             out = main_balance_info
             out["tokens"] = contracts_balance_info
             out["sum_fiat"] = f"{self.daemon.fx.ccy_amount_str(sum_fiat, True)} {self.ccy}"
-            out["coin_asset"] = self._fill_balance_info_with_coin(sum_fiat, coin)
+            out["coin_asset"] = (
+                self._fill_balance_info_with_coin(sum_fiat, coin)
+                if sum_fiat != Decimal(0)
+                else main_balance_info["balance"]
+            )
+
             out["name"] = self.wallet.identity
         elif chain_affinity == "eth":  # eth base
             main_balance_info, contracts_balance_info, sum_fiat = self._get_eth_wallet_all_balance(self.wallet)
             out = main_balance_info
             out["tokens"] = contracts_balance_info
             out["sum_fiat"] = f"{self.daemon.fx.ccy_amount_str(sum_fiat, True)} {self.ccy}"
-            out["coin_asset"] = self._fill_balance_info_with_coin(sum_fiat, coin)
+            out["coin_asset"] = (
+                self._fill_balance_info_with_coin(sum_fiat, coin)
+                if sum_fiat != Decimal(0)
+                else main_balance_info["balance"]
+            )
+
             out["name"] = self.wallet.identity
         elif (
             self.network
@@ -4567,7 +4577,9 @@ class AndroidCommands(commands.Commands):
                 {
                     "all_balance": f"{self.daemon.fx.ccy_amount_str(sum_fiat, True)} {self.ccy}",
                     "wallets": [main_balance_info] + contracts_balance_info,
-                    "coin_asset": self._fill_balance_info_with_coin(sum_fiat, coin),
+                    "coin_asset": self._fill_balance_info_with_coin(sum_fiat, coin)
+                    if sum_fiat != Decimal(0)
+                    else main_balance_info["balance"],
                 }
             )
         elif chain_affinity == "eth":
@@ -4576,7 +4588,9 @@ class AndroidCommands(commands.Commands):
                 {
                     "all_balance": f"{self.daemon.fx.ccy_amount_str(sum_fiat, True)} {self.ccy}",
                     "wallets": [main_balance_info] + contracts_balance_info,
-                    "coin_asset": self._fill_balance_info_with_coin(sum_fiat, coin),
+                    "coin_asset": self._fill_balance_info_with_coin(sum_fiat, coin)
+                    if sum_fiat != Decimal(0)
+                    else main_balance_info["balance"],
                 }
             )
         elif chain_affinity == "btc":


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
当获取不到法币价格时， 正确显示 coin_asset 值。

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
https://github.com/OneKeyHQ/TaskHub/issues/1904#issuecomment-863046505

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
…

## Any other comments?
…
