### PR TITLE
Fix query_accounts_by_addresses

### DIFF
--- a/electrum_gui/common/wallet/daos/account.py
+++ b/electrum_gui/common/wallet/daos/account.py
@@ -44,6 +44,6 @@ def query_accounts_by_ids(account_ids: List[int]) -> List[AccountModel]:
     return list(models)
 
 
-def query_accounts_by_addresses(chain_code: str, addresses: List[str]) -> List[AccountModel]:
-    models = AccountModel.select().where(AccountModel.chain_code == chain_code, AccountModel.address.in_(addresses))
+def query_accounts_by_addresses(wallet_id: int, addresses: List[str]) -> List[AccountModel]:
+    models = AccountModel.select().where(AccountModel.wallet_id == wallet_id, AccountModel.address.in_(addresses))
     return list(models)

--- a/electrum_gui/common/wallet/manager.py
+++ b/electrum_gui/common/wallet/manager.py
@@ -617,7 +617,7 @@ def send(
     if not is_valid:
         raise exceptions.IllegalUnsignedTx(validation_message)
 
-    accounts = daos.account.query_accounts_by_addresses(wallet.chain_code, [i.address for i in unsigned_tx.inputs])
+    accounts = daos.account.query_accounts_by_addresses(wallet.id, [i.address for i in unsigned_tx.inputs])
     signed_tx = _sign_tx(wallet, accounts, password, unsigned_tx)
 
     if auto_broadcast:
@@ -651,7 +651,7 @@ def _verify_unsigned_tx(wallet_id: int, coin_code: str, unsigned_tx: UnsignedTx)
     if not input_addresses:
         return False, "No input addresses found"
 
-    input_accounts = daos.account.query_accounts_by_addresses(wallet.chain_code, input_addresses)
+    input_accounts = daos.account.query_accounts_by_addresses(wallet.id, input_addresses)
     input_accounts_address_set = {i.address for i in input_accounts}
     if (
         not input_accounts


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
目前 wallet_manager 默认相同地址可以导入创建多次，所以这里需要应该用 wallet_id 来搜索

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
https://github.com/OneKeyHQ/TaskHub/issues/1904#issuecomment-863797949

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
…

## Any other comments?
…
