### PR TITLE
check the receiptIdentifier activation status

### DIFF
--- a/electrum_gui/common/provider/chains/stc/provider.py
+++ b/electrum_gui/common/provider/chains/stc/provider.py
@@ -86,13 +86,13 @@ class STCProvider(ProviderInterface):
         if tx_input is not None and tx_output is not None:
             from_address = tx_input.address
             to_address = tx_output.address
+            payee_auth_key = None
             if to_address.startswith("stc"):
                 ri = ReceiptIdentifier.decode(to_address)
                 require(ri is not None)
-                payee_auth_key = ri.auth_key
                 to_address = ri.account_address
-            else:
-                payee_auth_key = None
+                if not self.client.get_address(to_address).existing:
+                    payee_auth_key = ri.auth_key
 
             value = tx_output.value
             if tx_output.token_address:

--- a/electrum_gui/common/tests/unit/provider/chains/stc/test_provider.py
+++ b/electrum_gui/common/tests/unit/provider/chains/stc/test_provider.py
@@ -101,10 +101,6 @@ class TestSTCProvider(TestCase):
         )
 
     def test_fill_unsigned_tx(self):
-        # external_address_a = "0xb61a35af603018441b06177a8820ff2a"
-        # external_address_b = "0x194d36be65a955201ec79166b88ca18e"
-        contract_address = "0xb61a35af603018441b06177a8820ff2a"
-
         fake_client = Mock(
             get_prices_per_unit_of_fee=Mock(
                 return_value=PricesPerUnit(
@@ -115,15 +111,13 @@ class TestSTCProvider(TestCase):
             ),
             get_address=Mock(return_value=Mock(nonce=18)),
         )
-        fake_jsonRPC = Mock(
-            is_contract=Mock(side_effect=lambda address: address == contract_address),
-            estimate_gas_limit=Mock(return_value=100000000),
-        )
+
+        fake_json_rpc = Mock()
 
         def _client_selector_side_effect(**kwargs):
             instance_required = kwargs.get("instance_required")
             if instance_required and issubclass(instance_required, STCJsonRPC):
-                return fake_jsonRPC
+                return fake_json_rpc
             else:
                 return fake_client
 
@@ -131,38 +125,44 @@ class TestSTCProvider(TestCase):
 
         with self.subTest("Empty UnsignedTx"):
             self.assertEqual(
+                UnsignedTx(fee_limit=100000, fee_price_per_unit=int(1)),
                 self.provider.fill_unsigned_tx(
                     UnsignedTx(),
                 ),
-                UnsignedTx(fee_limit=100000, fee_price_per_unit=int(1)),
             )
-            fake_client.get_prices_per_unit_of_fee.assert_called_once()
-            fake_client.get_address.assert_not_called()
-            fake_jsonRPC.is_contract.assert_not_called()
-            fake_jsonRPC.estimate_gas_limit.assert_not_called()
-
-            fake_client.get_prices_per_unit_of_fee.reset_mock()
 
     def test_sign_transaction(self):
+        fake_client = Mock()
+        fake_json_rpc = Mock()
+
+        def _client_selector_side_effect(**kwargs):
+            instance_required = kwargs.get("instance_required")
+            if instance_required and issubclass(instance_required, STCJsonRPC):
+                return fake_json_rpc
+            else:
+                return fake_client
+
+        self.fake_client_selector.side_effect = _client_selector_side_effect
         self.fake_chain_info.chain_id = "251"
 
-        with self.subTest("Sign STC Transfer Tx with hex to address"):
-            fake_signer = Mock(
-                sign=Mock(
-                    return_value=(
-                        bytes.fromhex(
-                            "b4f0eb5b9994767f8e43885d4c50f5e066f14dee8c8c72bca1d717b392cb77d0738373e3bd1a7809c587afcbc8e31185bcdf0d288a63b01bca5eb7b713bed200"
-                        ),
-                        0,
-                    )
-                ),
-                get_pubkey=Mock(
-                    return_value=bytes(
-                        x for x in bytes.fromhex("7b945271879962dde59a0e170219d04a1c3ae3901de95041283c473902d0b03d")
-                    )
-                ),
-            )
-            signers = {"0xb61a35af603018441b06177a8820ff2a": fake_signer}
+        fake_signer = Mock(
+            sign=Mock(
+                return_value=(
+                    bytes.fromhex(
+                        "b4f0eb5b9994767f8e43885d4c50f5e066f14dee8c8c72bca1d717b392cb77d0738373e3bd1a7809c587afcbc8e31185bcdf0d288a63b01bca5eb7b713bed200"
+                    ),
+                    0,
+                )
+            ),
+            get_pubkey=Mock(
+                return_value=bytes(
+                    x for x in bytes.fromhex("7b945271879962dde59a0e170219d04a1c3ae3901de95041283c473902d0b03d")
+                )
+            ),
+        )
+        signers = {"0xb61a35af603018441b06177a8820ff2a": fake_signer}
+
+        with self.subTest("Sign STC Transfer Tx with hex to_address"):
             self.assertEqual(
                 SignedTx(
                     txid="0x55a8ab2df5db77e3be24304cc868f12fd35cb78e77842003d5f2aa17494adfd9",
@@ -183,23 +183,39 @@ class TestSTCProvider(TestCase):
                 ),
             )
 
-        with self.subTest("Sign STC Transfer Tx with ReceiptIdentifier"):
-            fake_signer = Mock(
-                sign=Mock(
-                    return_value=(
-                        bytes.fromhex(
-                            "b4f0eb5b9994767f8e43885d4c50f5e066f14dee8c8c72bca1d717b392cb77d0738373e3bd1a7809c587afcbc8e31185bcdf0d288a63b01bca5eb7b713bed200"
-                        ),
-                        0,
-                    )
+        with self.subTest("Sign STC Transfer Tx with existing ReceiptIdentifier"):
+            fake_client = Mock(
+                get_address=Mock(return_value=Mock(existing=True)),
+            )
+            self.assertEqual(
+                SignedTx(
+                    txid="0x55a8ab2df5db77e3be24304cc868f12fd35cb78e77842003d5f2aa17494adfd9",
+                    raw_tx="0xb61a35af603018441b06177a8820ff2a120000000000000002000000000000000000000000000000010f5472616e73666572536372697074730c706565725f746f5f706565720107000000000000000000000000000000010353544303535443000310194d36be65a955201ec79166b88ca18e01001000040000000000000000000000000000809698000000000001000000000000000d3078313a3a5354433a3a5354438a77a36000000000fb00207b945271879962dde59a0e170219d04a1c3ae3901de95041283c473902d0b03d40b4f0eb5b9994767f8e43885d4c50f5e066f14dee8c8c72bca1d717b392cb77d0738373e3bd1a7809c587afcbc8e31185bcdf0d288a63b01bca5eb7b713bed200",
                 ),
-                get_pubkey=Mock(
-                    return_value=bytes(
-                        x for x in bytes.fromhex("7b945271879962dde59a0e170219d04a1c3ae3901de95041283c473902d0b03d")
-                    )
+                self.provider.sign_transaction(
+                    self.provider.fill_unsigned_tx(
+                        UnsignedTx(
+                            inputs=[TransactionInput(address="0xb61a35af603018441b06177a8820ff2a", value=1024)],
+                            outputs=[
+                                TransactionOutput(
+                                    address="stc1pr9xnd0n9492jq8k8j9nt3r9p3cf88k6a7wtl9cyal2773ap3x6lpjnfkhej6j4fqrmreze4c3jscug7yx2e",
+                                    value=1024,
+                                )
+                            ],
+                            nonce=18,
+                            fee_price_per_unit=1,
+                            fee_limit=10000000,
+                            payload={"expiration_time": 1621325706},
+                        ),
+                    ),
+                    signers,
                 ),
             )
-            signers = {"0xb61a35af603018441b06177a8820ff2a": fake_signer}
+
+        with self.subTest("Sign STC Transfer Tx with  a nonexistent ReceiptIdentifier"):
+            fake_client = Mock(
+                get_address=Mock(return_value=Mock(existing=False)),
+            )
             self.assertEqual(
                 SignedTx(
                     txid="0x4fe1184686c5d2270833a55fdbfb83e6551cb8c56452cc9ea58ff55c1277aac5",


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
判断 `ReceiptIdentifier` 是否在链上已存在，存在情况下，自动转换成 `0x` 地址发送，可以降低 gasUsed。此改动前端不受影响。

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
https://github.com/OneKeyHQ/TaskHub/issues/1904

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
…

## Any other comments?
…
