### PR TITLE
stc: support estimate_gas_limit

### DIFF
--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -3246,6 +3246,12 @@ class AndroidCommands(commands.Commands):
                 validation = provider_manager.verify_address(chain_code, data)
                 if not validation.is_valid:
                     raise exceptions.IncorrectAddress()
+                if (
+                    chain_affinity == "stc"
+                    and validation.encoding == "HEX"
+                    and not provider_manager.get_address(chain_code, data).existing
+                ):
+                    raise exceptions.InactiveAddress()
         elif chain_affinity == "btc":
             if flag == "private":
                 try:

--- a/electrum_gui/common/basic/exceptions.py
+++ b/electrum_gui/common/basic/exceptions.py
@@ -55,6 +55,10 @@ class IncorrectAddress(OneKeyException):
     key = "msg__incorrect_address"
 
 
+class InactiveAddress(OneKeyException):
+    key = "msg__the_address_has_not_been_activated_please_enter_receipt_identifier"
+
+
 def catch_exception(force_api_version: int = None):
     def middle(func):
         @functools.wraps(func)

--- a/electrum_gui/common/provider/chains/stc/clients/jsonrpc.py
+++ b/electrum_gui/common/provider/chains/stc/clients/jsonrpc.py
@@ -194,3 +194,10 @@ class STCJsonRPC(ClientInterface):
             normal=EstimatedTimeOnPrice(price=normal, time=60),
             slow=EstimatedTimeOnPrice(price=slow, time=60),
         )
+
+    def estimate_gas_limit(self, params=dict) -> int:
+        resp = self.rpc.call("contract.dry_run", params=[params])
+        if resp.get("status") == 'Executed':
+            return int(resp.get("gas_used"))
+        else:
+            return 0

--- a/electrum_gui/common/provider/data.py
+++ b/electrum_gui/common/provider/data.py
@@ -63,6 +63,7 @@ class TransactionInput(DataClassMixin):
     value: int
     token_address: Optional[str] = None
     utxo: Optional[UTXO] = None
+    pubkey: Optional[str] = None
 
 
 @dataclass

--- a/electrum_gui/common/tests/unit/provider/chains/stc/test_provider.py
+++ b/electrum_gui/common/tests/unit/provider/chains/stc/test_provider.py
@@ -23,17 +23,21 @@ class TestSTCProvider(TestCase):
             coins_loader=self.fake_coins_loader,
             client_selector=self.fake_client_selector,
         )
+        self.fake_chain_info.chain_id = "251"
 
     def test_verify_address(self):
         self.assertEqual(
             AddressValidation(
-                "0xb61a35af603018441b06177a8820ff2a", "0xb61a35af603018441b06177a8820ff2a", is_valid=True, encoding=None
+                "0xb61a35af603018441b06177a8820ff2a",
+                "0xb61a35af603018441b06177a8820ff2a",
+                is_valid=True,
+                encoding="HEX",
             ),
             self.provider.verify_address("0xb61a35af603018441b06177a8820ff2a"),
         )
         self.assertEqual(
             AddressValidation(
-                "b61a35af603018441b06177a8820ff2a", "b61a35af603018441b06177a8820ff2a", is_valid=True, encoding=None
+                "b61a35af603018441b06177a8820ff2a", "b61a35af603018441b06177a8820ff2a", is_valid=True, encoding="HEX"
             ),
             self.provider.verify_address("b61a35af603018441b06177a8820ff2a"),
         )
@@ -125,7 +129,7 @@ class TestSTCProvider(TestCase):
 
         with self.subTest("Empty UnsignedTx"):
             self.assertEqual(
-                UnsignedTx(fee_limit=100000, fee_price_per_unit=int(1)),
+                UnsignedTx(fee_limit=10000000, fee_price_per_unit=int(1)),
                 self.provider.fill_unsigned_tx(
                     UnsignedTx(),
                 ),
@@ -143,7 +147,6 @@ class TestSTCProvider(TestCase):
                 return fake_client
 
         self.fake_client_selector.side_effect = _client_selector_side_effect
-        self.fake_chain_info.chain_id = "251"
 
         fake_signer = Mock(
             sign=Mock(


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
- 使用 [`contract.dry_run`](https://playground.open-rpc.org/?schemaUrl=https://developer.starcoin.org/rpc/schema/contract.json) 预估手续费
- 验证地址合法性的时候，stc 会单独判断地址是否存在。
- 增加 msg__the_address_has_not_been_activated_please_enter_receipt_identifier i18n key。 @reepig
## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
https://github.com/OneKeyHQ/TaskHub/issues/1904

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
…

## Any other comments?
gas_limit 返回的接口预估值， 没有做类似数值扩大的操作。
