### PR TITLE
reorganize api & exceptions

### DIFF
--- a/electrum/util.py
+++ b/electrum/util.py
@@ -238,13 +238,6 @@ class UserFacingException(Exception):
 class InvoiceError(UserFacingException): pass
 
 
-class DecimalEncoder(json.JSONEncoder):
-    def default(self, o):
-        if isinstance(o, decimal.Decimal):
-            return f"{o.normalize():f}"
-        return super(DecimalEncoder, self).default(o)
-
-
 class Ticker(Timer):
     def run(self):
         while not self.finished.is_set():

--- a/electrum_gui/common/basic/api.py
+++ b/electrum_gui/common/basic/api.py
@@ -1,0 +1,64 @@
+import enum
+import functools
+import json
+
+from electrum_gui.common.basic import exceptions
+from electrum_gui.common.basic.functional import json_encoders
+
+
+@enum.unique
+class Version(enum.IntEnum):
+    V1 = 1
+    V2 = 2
+
+
+@enum.unique
+class ResultStatus(enum.IntEnum):
+    SUCCESS = 0
+    FAILED = 1
+    APP_USED = 2
+
+
+def api_entry(force_version: int = None):
+    def middle(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            def _filter_params(err=None):
+                error_msg = {"fun_name": func.__name__}
+                error_msg.update({k: v for k, v in kwargs.items() if k not in ["seed", "password", "mnemonic"]})
+                if err is not None:
+                    error_msg.update({"err_msg_detail": "%s:%s" % (err.__class__.__name__, err.args)})
+                return error_msg
+
+            api_version = kwargs.pop("api_version", Version.V1)
+            api_version = force_version or api_version
+
+            if api_version == Version.V1:
+                return func(*args, **kwargs)
+            elif api_version == Version.V2:
+                try:
+                    result = func(*args, **kwargs)
+                    out = {"status": ResultStatus.SUCCESS, "info": result}
+                except exceptions.OneKeyException as e:
+                    out = {"status": ResultStatus.FAILED, "err_msg_key": e.key}
+                except Exception as e:
+                    out = {
+                        "status": ResultStatus.FAILED,
+                        "err_msg_key": exceptions.OneKeyException.key,
+                        "low_level_error": _filter_params(e),
+                    }
+                out.update({"api_version": api_version})
+                return json.dumps(out, cls=json_encoders.DecimalEncoder)
+            else:
+                return json.dumps(
+                    {
+                        "status": ResultStatus.FAILED,
+                        "err_msg_key": "msg_unknown_error",
+                        "low_level_error": "unsupported api version",
+                        "api_version": api_version,
+                    }
+                )
+
+        return wrapper
+
+    return middle

--- a/electrum_gui/common/basic/dataclass/dataclass.py
+++ b/electrum_gui/common/basic/dataclass/dataclass.py
@@ -1,9 +1,9 @@
 import json
-from dataclasses import replace, asdict, fields
-from typing import Set
+from dataclasses import asdict, fields, replace
 from decimal import Decimal
+from typing import Set
 
-from electrum.util import DecimalEncoder
+from electrum_gui.common.basic.functional import json_encoders
 
 
 class DataClassMixin(object):
@@ -42,11 +42,9 @@ class DataClassMixin(object):
         decimal_fields = cls._load_decimal_fields()
 
         if decimal_fields:
-            data = {
-                k: Decimal(v) if k in decimal_fields else v for k, v in data.items()
-            }
+            data = {k: Decimal(v) if k in decimal_fields else v for k, v in data.items()}
 
         return data
 
     def to_json(self):
-        return json.dumps(self.to_dict(), cls=DecimalEncoder)
+        return json.dumps(self.to_dict(), cls=json_encoders.DecimalEncoder)

--- a/electrum_gui/common/basic/exceptions.py
+++ b/electrum_gui/common/basic/exceptions.py
@@ -1,26 +1,5 @@
-import functools
-import json
-from enum import IntEnum, unique
-
-from electrum.util import DecimalEncoder
-
-
-@unique
-class ResultStatus(IntEnum):
-    SUCCESS = 0
-    FAILED = 1
-    APP_USED = 2
-
-
-@unique
-class ApiVersion(IntEnum):
-    V1 = 1
-    V2 = 2
-
-
 class OneKeyException(Exception):
     key = "msg__unknown_error"
-    status = ResultStatus.FAILED
 
 
 class UnavailablePrivateKey(OneKeyException):
@@ -57,48 +36,3 @@ class IncorrectAddress(OneKeyException):
 
 class InactiveAddress(OneKeyException):
     key = "msg__the_address_has_not_been_activated_please_enter_receipt_identifier"
-
-
-def catch_exception(force_api_version: int = None):
-    def middle(func):
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            def _filter_params(err=None):
-                error_msg = {"fun_name": func.__name__}
-                error_msg.update({k: v for k, v in kwargs.items() if k not in ["seed", "password", "mnemonic"]})
-                if err is not None:
-                    error_msg.update({"err_msg_detail": "%s:%s" % (err.__class__.__name__, err.args)})
-                return error_msg
-
-            api_version = kwargs.pop("api_version", ApiVersion.V1)
-            api_version = force_api_version or api_version
-
-            if api_version == ApiVersion.V1:
-                return func(*args, **kwargs)
-            elif api_version == ApiVersion.V2:
-                try:
-                    result = func(*args, **kwargs)
-                    out = {"status": ResultStatus.SUCCESS, "info": result}
-                except OneKeyException as e:
-                    out = {"status": e.status, "err_msg_key": e.key}
-                except Exception as e:
-                    out = {
-                        "status": OneKeyException.status,
-                        "err_msg_key": OneKeyException.key,
-                        "low_level_error": _filter_params(e),
-                    }
-                out.update({"api_version": api_version})
-                return json.dumps(out, cls=DecimalEncoder)
-            else:
-                return json.dumps(
-                    {
-                        "status": ResultStatus.FAILED,
-                        "err_msg_key": "msg_unknown_error",
-                        "low_level_error": "unsupported api version",
-                        "api_version": api_version,
-                    }
-                )
-
-        return wrapper
-
-    return middle

--- a/electrum_gui/common/basic/functional/json_encoders.py
+++ b/electrum_gui/common/basic/functional/json_encoders.py
@@ -1,0 +1,9 @@
+import decimal
+import json
+
+
+class DecimalEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, decimal.Decimal):
+            return f"{o.normalize():f}"
+        return super(DecimalEncoder, self).default(o)


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
- 整理了API和exceptions，将两者分开
- json的DecimalEncoder放到该放的地方
- import和一些命名的整理，非引入新框架的内容暂时没管
  - import 看[这里](https://google.github.io/styleguide/pyguide.html#22-imports)
  - 命名根据上一条的逻辑，可以把模块名认为命名的一部分。比如`api.py`里起名`Version`那么使用时就是`api.Version`，而如果按原来的命名`ApiVersion`就是`api.ApiVersion`，后者就显得有些重复了

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
OneKeyHQ/TaskHub#1448

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
No

## Any other comments?
把`api_entry`拿出来主要目的是以后加上参数验证，前后端分离之后会有个大的params参数，考虑加上jsonschema就可以做参数基础格式的验证。