### PR TITLE
Transaction related

### DIFF
--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -16,7 +16,7 @@ from contextlib import contextmanager
 from decimal import Decimal
 from operator import attrgetter
 from os.path import exists, join
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 import eth_abi
 import eth_utils
@@ -68,6 +68,7 @@ from electrum.util import (
     UserCancel,
     bfh,
     create_and_start_event_loop,
+    format_time,
 )
 from electrum.util import user_dir as get_dir
 from electrum.wallet import Imported_Wallet, Standard_Wallet, Wallet
@@ -86,6 +87,8 @@ from electrum_gui.common.provider import exceptions as provider_exceptions
 from electrum_gui.common.provider import provider_manager
 from electrum_gui.common.provider.chains.eth.clients import geth as geth_client
 from electrum_gui.common.secret import manager as secret_manager
+from electrum_gui.common.transaction import data as transaction_data
+from electrum_gui.common.transaction import manager as transaction_manager
 from electrum_gui.common.wallet import bip44
 from electrum_gui.common.wallet import manager as wallet_manager
 
@@ -1697,71 +1700,111 @@ class AndroidCommands(commands.Commands):
             self.old_history_info = all_data
             return json.dumps(all_data[start:end])
 
-    def get_general_coin_tx_list(self, contract_address=None, search_type=None):
-        ret = []
+    def get_general_coin_tx_list(
+        self,
+        coin: str,
+        address: str,
+        token_address: str = None,
+        search_type: str = None,
+        start: int = None,
+        end: int = None,
+    ):
+        chain_code = coin_manager.legacy_coin_to_chain_code(coin)
+        __, transfer_coin, fee_coin = coin_manager.get_related_coins(chain_code)
 
-        chain_code = coin_manager.legacy_coin_to_chain_code(self.wallet.coin)
-        main_coin = coin_manager.get_coin_info(chain_code)
-        main_coin_price = price_manager.get_last_price(main_coin.code, self.ccy)
-        if contract_address is not None:
-            # Normalize contract address
-            contract_address = provider_manager.verify_address(chain_code, contract_address).normalized_address
-            coin = coin_manager.get_coin_by_token_address(chain_code, contract_address)
-            coin_price = price_manager.get_last_price(coin.code, self.ccy)
-        else:
-            contract_address = None
-            coin = main_coin
-            coin_price = main_coin_price
+        if token_address:
+            token_address = provider_manager.verify_address(chain_code, token_address).normalized_address
+            transfer_coin = coin_manager.get_coin_by_token_address(chain_code, token_address)
 
-        main_coin_decimal_divisor = pow(10, main_coin.decimals)
-        coin_decimal_divisor = pow(10, coin.decimals)
-        address = self.wallet.get_addresses()[0].lower()
-        for transaction in provider_manager.search_txs_by_address(chain_code, address):
-            fee = Decimal(transaction.fee.used * transaction.fee.price_per_unit / main_coin_decimal_divisor)
-            fee_fiat = fee * main_coin_price
-            detailed_status = transaction.detailed_status
-            show_status = transaction.show_status
-            date_str = transaction.date_str
-            height = transaction.height
-            confirmations = transaction.confirmations
+        start = start or 0
+        end = end or start + 20
+        items_per_page = max(end - start, 20)
+        page_number = max(round(start / items_per_page), 0) + 1
 
-            for input, output in zip(transaction.inputs, transaction.outputs):
-                if output.token_address != contract_address:
-                    continue
+        searching_address_as: Literal["sender", "receiver", "both"] = "both"
+        if search_type == "send":
+            searching_address_as = "sender"
+        elif search_type == "receive":
+            searching_address_as = "receiver"
 
-                input_address = input.address.lower()
-                output_address = output.address.lower()
+        actions = transaction_manager.query_actions_by_address(
+            chain_code=chain_code,
+            coin_code=transfer_coin.code,
+            address=address,
+            page_number=page_number,
+            items_per_page=items_per_page,
+            searching_address_as=searching_address_as,
+        )
+        if not actions:
+            return []
 
-                if search_type == "send" and input_address != address:
-                    continue
-                elif search_type == "receive" and output_address != address:
-                    continue
-                elif input_address != address and output_address != address:
-                    continue
+        try:
+            best_block_number = provider_manager.get_best_block_number(chain_code)
+        except Exception as e:
+            log_info.exception(f"Error in get_best_block_number. chain_code: {chain_code}, error: {e}")
+            best_block_number = 0
 
-                show_address = output_address if input_address == address else input_address
-                amount = Decimal(output.value) / coin_decimal_divisor
-                fiat = amount * coin_price
-                ret.append(
-                    {
-                        "type": "histroy",
-                        "coin": coin.symbol,
-                        "tx_status": detailed_status,
-                        "show_status": show_status,
-                        "fee": f"{fee} {main_coin.symbol} ({self.daemon.fx.ccy_amount_str(fee_fiat, True)} {self.ccy})",
-                        "date": date_str,
-                        "tx_hash": transaction.txid,
-                        "is_mine": input_address == address,
-                        "height": height,
-                        "confirmations": confirmations,
-                        "input_addr": [input_address],
-                        "output_addr": [output_address],
-                        "address": f"{show_address[:6]}...{show_address[-6:]}",
-                        "amount": f"{amount.normalize():f} {coin.symbol} ({self.daemon.fx.ccy_amount_str(fiat, True)} {self.ccy})",
-                    }
-                )
+        address = provider_manager.verify_address(chain_code, address).normalized_address
+        transfer_coin_price = price_manager.get_last_price(transfer_coin.code, self.ccy)
+        fee_coin_price = (
+            transfer_coin_price
+            if fee_coin.code == transfer_coin.code
+            else price_manager.get_last_price(fee_coin.code, self.ccy)
+        )
+        transfer_coin_decimal_divisor = pow(10, transfer_coin.decimals)
+        fee_coin_decimal_divisor = pow(10, fee_coin.decimals)
 
-        return json.dumps(ret, cls=json_encoders.DecimalEncoder)
+        result = []
+        processing_statuses = {
+            transaction_data.TxActionStatus.CONFIRM_REVERTED,
+            transaction_data.TxActionStatus.CONFIRM_SUCCESS,
+            transaction_data.TxActionStatus.PENDING,
+        }
+
+        for action in actions:
+            if action.status not in processing_statuses:
+                continue
+
+            show_address = action.to_address if action.from_address == address else action.from_address
+
+            transfer_value = action.value / transfer_coin_decimal_divisor
+            transfer_fiat = transfer_value * transfer_coin_price
+            fee_value = (action.fee_used or action.fee_limit) * action.fee_price_per_unit / fee_coin_decimal_divisor
+            fee_fiat = fee_value * fee_coin_price
+
+            confirmed_date_str = format_time(action.block_time) if action.block_time is not None else _("Unknown")
+            confirmed_block_number = action.block_number if action.block_number is not None else 0
+            confirmed_number = max(best_block_number - confirmed_block_number, 0) if confirmed_block_number > 0 else 0
+
+            detailed_status = {"status": action.status, "other_info": ""}
+            if action.status == transaction_data.TxActionStatus.CONFIRM_REVERTED:
+                show_status_desc = _("Sending failure")
+            elif action.status == transaction_data.TxActionStatus.CONFIRM_SUCCESS:
+                show_status_desc = _("Confirmed")
+            else:
+                show_status_desc = _("Unconfirmed")
+
+            item = {
+                "type": "histroy",
+                "coin": transfer_coin.symbol,
+                "tx_status": detailed_status,
+                "show_status": [action.status, show_status_desc],
+                "fee": f"{fee_value.normalize():f} {fee_coin.symbol} "
+                       f"({self.daemon.fx.ccy_amount_str(fee_fiat, True)} {self.ccy})",
+                "date": confirmed_date_str,
+                "tx_hash": action.txid,
+                "is_mine": action.from_address == address,
+                "height": confirmed_block_number,
+                "confirmations": confirmed_number,
+                "input_addr": [action.from_address],
+                "output_addr": [action.to_address],
+                "address": f"{show_address[:6]}...{show_address[-6:]}",
+                "amount": f"{transfer_value.normalize():f} {transfer_coin.symbol} "
+                f"({self.daemon.fx.ccy_amount_str(transfer_fiat, True)} {self.ccy})",
+            }
+            result.append(item)
+
+        return json.dumps(result, cls=json_encoders.DecimalEncoder)
 
     @api.api_entry()
     def get_detail_tx_info_by_hash(self, tx_hash):
@@ -1821,7 +1864,14 @@ class AndroidCommands(commands.Commands):
             if chain_affinity == "btc":
                 return self.get_btc_tx_list(start=start, end=end, search_type=search_type)
             elif chain_affinity == "eth" or is_coin_migrated(coin):
-                return self.get_general_coin_tx_list(contract_address=contract_address, search_type=search_type)
+                return self.get_general_coin_tx_list(
+                    coin=self.wallet.coin,
+                    address=self.wallet.get_addresses()[0],
+                    token_address=contract_address,
+                    search_type=search_type,
+                    start=start,
+                    end=end,
+                )
             else:
                 raise UnsupportedCurrencyCoin()
 

--- a/electrum_gui/common/provider/chains/eth/clients/blockbook.py
+++ b/electrum_gui/common/provider/chains/eth/clients/blockbook.py
@@ -46,7 +46,7 @@ class BlockBook(ClientInterface, SearchTransactionMixin):
     }
 
     def __init__(self, url: str):
-        self.restful = RestfulRequest(url)
+        self.restful = RestfulRequest(url, timeout=10)
 
     def get_info(self) -> ClientInfo:
         resp = self.restful.get("/api/v2")
@@ -196,6 +196,9 @@ class BlockBook(ClientInterface, SearchTransactionMixin):
 
         if paginate.start_block_number is not None:
             payload["from"] = paginate.start_block_number
+
+        if paginate.end_block_number is not None:
+            payload["to"] = paginate.end_block_number
 
         if paginate.page_number is not None:
             payload["page"] = paginate.page_number

--- a/electrum_gui/common/provider/chains/eth/clients/etherscan.py
+++ b/electrum_gui/common/provider/chains/eth/clients/etherscan.py
@@ -26,7 +26,7 @@ from electrum_gui.common.provider.interfaces import ClientInterface, SearchTrans
 
 class Etherscan(ClientInterface, SearchTransactionMixin):
     def __init__(self, url: str, api_keys: List[str] = None):
-        self.restful = RestfulRequest(url)
+        self.restful = RestfulRequest(url, timeout=10)
         self.api_key = api_keys[0] if api_keys else None
 
     def _call_action(self, module: str, action: str, **kwargs) -> dict:
@@ -121,6 +121,9 @@ class Etherscan(ClientInterface, SearchTransactionMixin):
 
         if paginate.start_block_number is not None:
             payload["startblock"] = paginate.start_block_number
+
+        if paginate.end_block_number is not None:
+            payload["endblock"] = paginate.end_block_number
 
         if paginate.page_number is not None:
             payload["page"] = paginate.page_number

--- a/electrum_gui/common/provider/data.py
+++ b/electrum_gui/common/provider/data.py
@@ -129,7 +129,8 @@ class Transaction(DataClassMixin):
 
 @dataclass
 class TxPaginate(DataClassMixin):
-    start_block_number: int
+    start_block_number: int = None
+    end_block_number: int = None
     page_number: int = 1  # start from 1
     items_per_page: int = None
 

--- a/electrum_gui/common/provider/manager.py
+++ b/electrum_gui/common/provider/manager.py
@@ -6,6 +6,10 @@ from electrum_gui.common.provider import data, exceptions, interfaces, loader
 from electrum_gui.common.secret import interfaces as secret_interfaces
 
 
+def get_best_block_number(chain_code: str) -> int:
+    return loader.get_client_by_chain(chain_code).get_info().best_block_number
+
+
 def get_address(chain_code: str, address: str) -> data.Address:
     return loader.get_client_by_chain(chain_code).get_address(address)
 

--- a/electrum_gui/common/tests/unit/transaction/test_manager.py
+++ b/electrum_gui/common/tests/unit/transaction/test_manager.py
@@ -3,6 +3,8 @@ import decimal
 from unittest import TestCase
 from unittest.mock import Mock, call, patch
 
+import peewee
+
 from electrum_gui.common.basic.orm import test_utils
 from electrum_gui.common.coin import data as coin_data
 from electrum_gui.common.provider import data as provider_data
@@ -22,8 +24,6 @@ class TestTransactionManager(TestCase):
                     chain_code="eth",
                     coin_code="eth",
                     value=decimal.Decimal(0),
-                    decimals=decimal.Decimal(18),
-                    symbol="ETH",
                     from_address="address_a",
                     to_address="contract_a",
                     fee_limit=decimal.Decimal(1000),
@@ -37,8 +37,6 @@ class TestTransactionManager(TestCase):
                     chain_code="eth",
                     coin_code="eth_usdt",
                     value=decimal.Decimal(10),
-                    decimals=decimal.Decimal(6),
-                    symbol="USDT",
                     from_address="address_a",
                     to_address="address_b",
                     fee_limit=decimal.Decimal(1000),
@@ -52,8 +50,6 @@ class TestTransactionManager(TestCase):
                     chain_code="bsc",
                     coin_code="bsc",
                     value=decimal.Decimal(3),
-                    decimals=decimal.Decimal(18),
-                    symbol="BSC",
                     from_address="address_b",
                     to_address="address_c",
                     fee_limit=decimal.Decimal(1000),
@@ -67,8 +63,6 @@ class TestTransactionManager(TestCase):
                     chain_code="heco",
                     coin_code="heco",
                     value=decimal.Decimal(4),
-                    decimals=decimal.Decimal(18),
-                    symbol="HECO",
                     from_address="address_c",
                     to_address="address_b",
                     fee_limit=decimal.Decimal(1000),
@@ -175,175 +169,372 @@ class TestTransactionManager(TestCase):
             [call('bsc', 'txid_b'), call('eth', 'txid_a'), call('heco', 'txid_c')]
         )
 
-    @patch("electrum_gui.common.transaction.manager.coin_manager")
-    def test_sync_address_actions_utxo_model(self, fake_coin_manager):
-        fake_coin_manager.get_chain_info.return_value = Mock(chain_model=coin_data.ChainModel.UTXO)
+    def test_unique_indexes_of_tx_action(self):
+        models.TxAction.create(
+            txid="txid_a",
+            status=data.TxActionStatus.CONFIRM_SUCCESS,
+            chain_code="eth",
+            coin_code="eth",
+            value=decimal.Decimal(0),
+            from_address="address_a",
+            to_address="contract_a",
+            fee_limit=decimal.Decimal(1000),
+            fee_price_per_unit=decimal.Decimal(20),
+            raw_tx="",
+            nonce=0,
+            index=0,
+        )
 
         with self.assertRaisesRegex(
-            Exception, "This chain model isn't supported yet. chain_code: btc, chain_model: <ChainModel.UTXO: 10>"
+            peewee.IntegrityError, "UNIQUE constraint failed: txaction.txid, txaction.coin_code, txaction.index"
         ):
-            manager.sync_address_actions("btc", "fake_btc_address")
+            models.TxAction.create(
+                txid="txid_a",
+                status=data.TxActionStatus.CONFIRM_SUCCESS,
+                chain_code="eth",
+                coin_code="eth",
+                value=decimal.Decimal(0),
+                from_address="address_a",
+                to_address="contract_a",
+                fee_limit=decimal.Decimal(1000),
+                fee_price_per_unit=decimal.Decimal(20),
+                raw_tx="",
+                nonce=0,
+                index=0,
+            )
 
-    @patch("electrum_gui.common.transaction.manager.coin_manager")
     @patch("electrum_gui.common.transaction.manager.provider_manager")
-    def test_sync_address_actions_account_model(self, fake_provider_manager, fake_coin_manager):
+    @patch("electrum_gui.common.transaction.manager.coin_manager")
+    @patch("electrum_gui.common.transaction.manager.time")
+    def test_query_actions_by_address(self, fake_time, fake_coin_manager, fake_provider_manager):
         fake_coin_manager.get_chain_info.return_value = Mock(chain_model=coin_data.ChainModel.ACCOUNT)
-        fake_coin_manager.get_coin_info.return_value = Mock(code="eth", symbol="ETH", decimals=18)
-        fake_coin_manager.query_coins_by_token_addresses.return_value = [
-            Mock(code="eth_usdt", symbol="USDT", decimals=6, token_address="contract_a")
+        fake_coin_manager.get_coin_info.return_value = Mock(code="eth")
+        fake_coin_manager.query_coins_by_token_addresses.return_value = []
+        fake_provider_manager.verify_address.side_effect = lambda chain_code, address: Mock(normalized_address=address)
+
+        def _build_action_by_pattern(txid: str, **kwargs):
+            pattern = dict(
+                chain_code="eth",
+                coin_code="eth",
+                value=decimal.Decimal(10),
+                from_address="address_a",
+                to_address="address_b",
+                fee_limit=decimal.Decimal(1000),
+                fee_price_per_unit=decimal.Decimal(20),
+                raw_tx="",
+            )
+            _data = pattern.copy()
+            _data.update(kwargs)
+            _data["txid"] = txid
+            return daos.new_action(**_data)
+
+        # 1. prepare existing actions
+        daos.bulk_create(
+            [
+                _build_action_by_pattern(
+                    "txid_from_a_100",
+                    status=data.TxActionStatus.PENDING,
+                    nonce=100,
+                    created_time=datetime.datetime.utcfromtimestamp(1620000002),
+                ),
+                _build_action_by_pattern(
+                    "txid_from_a_99",
+                    status=data.TxActionStatus.PENDING,
+                    nonce=99,
+                    created_time=datetime.datetime.utcfromtimestamp(1620000001),
+                ),
+            ]
+        )
+        self.assertEqual(2, models.TxAction.select().count())
+
+        # 2. prepare fake txs
+        send_from_a = [
+            provider_data.Transaction(
+                txid=f"txid_from_a_{i}",
+                status=provider_data.TransactionStatus.CONFIRM_SUCCESS,
+                inputs=[provider_data.TransactionInput(address="address_a", value=10)],
+                outputs=[provider_data.TransactionOutput(address="address_b", value=10)],
+                fee=provider_data.TransactionFee(limit=1000, used=900, price_per_unit=20),
+                nonce=i,
+            )
+            for i in range(100)
+        ]
+        send_to_a = [
+            provider_data.Transaction(
+                txid=f"txid_to_a_{i}",
+                status=provider_data.TransactionStatus.CONFIRM_SUCCESS,
+                inputs=[provider_data.TransactionInput(address=f"address_{i}", value=10)],
+                outputs=[provider_data.TransactionOutput(address="address_a", value=10)],
+                fee=provider_data.TransactionFee(limit=1000, used=900, price_per_unit=20),
+                nonce=0,
+            )
+            for i in range(200)
+        ]
+        txs = send_to_a[:100] + send_from_a + send_to_a[100:]
+
+        for index, tx in enumerate(txs):
+            tx.block_header = provider_data.BlockHeader(
+                block_hash=f"block_{index}", block_number=index, block_time=1610000000 + index
+            )
+        txs.sort(key=lambda i: i.block_header.block_number, reverse=True)
+
+        txids = [i.txid for i in txs]
+        txids.remove("txid_from_a_99")
+        txids = ["txid_from_a_100", "txid_from_a_99", *txids]
+
+        fake_provider_manager.search_txs_by_address.side_effect = lambda chain_code, address, paginate: [
+            i
+            for i in txs
+            if (not paginate.start_block_number or i.block_header.block_number >= paginate.start_block_number)
+            and (not paginate.end_block_number or i.block_header.block_number <= paginate.end_block_number)
+        ][: paginate.items_per_page]
+
+        # 2. fetch the first page
+        fake_time.time.return_value = 1620000000
+        local_actions = manager.query_actions_by_address("eth", "eth", "address_a")
+        self.assertEqual(
+            txids[:20],
+            [i.txid for i in local_actions],
+        )
+        self.assertEqual(201, models.TxAction.select().count())
+        fake_time.time.assert_called_once()
+        fake_provider_manager.verify_address.assert_called_once_with("eth", "address_a")
+        fake_provider_manager.search_txs_by_address.assert_called_once_with(
+            "eth", "address_a", paginate=provider_data.TxPaginate(items_per_page=200)
+        )
+        fake_time.time.reset_mock()
+        fake_provider_manager.verify_address.reset_mock()
+        fake_provider_manager.search_txs_by_address.reset_mock()
+
+        # 3. fetch the following 9 pages without network
+        for page_number in range(2, 11):
+            local_actions.extend(manager.query_actions_by_address("eth", "eth", "address_a", page_number=page_number))
+
+        self.assertEqual(201, models.TxAction.select().count())
+        self.assertEqual(200, len(local_actions))
+        self.assertEqual(txids[:200], [i.txid for i in local_actions])
+        self.assertEqual(9, fake_provider_manager.verify_address.call_count)
+        fake_time.time.assert_not_called()
+        fake_provider_manager.search_txs_by_address.assert_not_called()
+
+        # 4. fetch the remaining txs
+        local_actions.extend(manager.query_actions_by_address("eth", "eth", "address_a", page_number=11))
+
+        self.assertEqual(301, models.TxAction.select().count())
+        fake_time.time.assert_not_called()
+        fake_provider_manager.search_txs_by_address.assert_called_once_with(
+            "eth", "address_a", paginate=provider_data.TxPaginate(end_block_number=100, items_per_page=200)
+        )
+        fake_provider_manager.search_txs_by_address.reset_mock()
+
+        # 5. fetch the following 4 pages without network
+        for page_number in range(12, 16):
+            local_actions.extend(manager.query_actions_by_address("eth", "eth", "address_a", page_number=page_number))
+
+        self.assertEqual(301, models.TxAction.select().count())
+        self.assertEqual(300, len(local_actions))
+        self.assertEqual(txids[:300], [i.txid for i in local_actions])
+        fake_time.time.assert_not_called()
+        fake_provider_manager.search_txs_by_address.assert_not_called()
+        fake_provider_manager.search_txs_by_address.reset_mock()
+
+        # 6. fetch the final page
+        local_actions.extend(manager.query_actions_by_address("eth", "eth", "address_a", page_number=16))
+        self.assertEqual(301, len(local_actions))
+        self.assertEqual(txids, [i.txid for i in local_actions])
+        fake_time.time.assert_not_called()
+        fake_provider_manager.search_txs_by_address.assert_called_once_with(
+            "eth", "address_a", paginate=provider_data.TxPaginate(end_block_number=0, items_per_page=200)
+        )
+        fake_provider_manager.search_txs_by_address.reset_mock()
+
+        # 7. suppose there are new data after a while, prepare new data
+        send_from_a = [
+            provider_data.Transaction(
+                txid=f"txid_from_a_{i}",
+                status=provider_data.TransactionStatus.CONFIRM_SUCCESS,
+                inputs=[provider_data.TransactionInput(address="address_a", value=10)],
+                outputs=[provider_data.TransactionOutput(address="address_b", value=10)],
+                fee=provider_data.TransactionFee(limit=1000, used=900, price_per_unit=20),
+                nonce=i,
+            )
+            for i in range(100, 300)
+        ]
+        send_to_a = [
+            provider_data.Transaction(
+                txid=f"txid_to_a_{i}",
+                status=provider_data.TransactionStatus.CONFIRM_SUCCESS,
+                inputs=[provider_data.TransactionInput(address=f"address_{i}", value=10)],
+                outputs=[provider_data.TransactionOutput(address="address_a", value=10)],
+                fee=provider_data.TransactionFee(limit=1000, used=900, price_per_unit=20),
+                nonce=0,
+            )
+            for i in range(200, 300)
         ]
 
-        fake_txs = [
+        new_txs = send_from_a[:100] + send_to_a + send_from_a[100:]
+
+        for index, tx in enumerate(new_txs):
+            tx.block_header = provider_data.BlockHeader(
+                block_hash=f"block_{index}", block_number=index + 300, block_time=1640000000 + index
+            )
+
+        new_txs.sort(key=lambda i: i.block_header.block_number, reverse=True)
+        new_txids = [i.txid for i in new_txs]
+        new_txs.extend(txs)
+        txs.clear()
+        txs.extend(new_txs)
+        txs.sort(key=lambda i: i.block_header.block_number, reverse=True)
+
+        new_txids.remove("txid_from_a_100")
+        txids = [*new_txids, *txids]
+
+        # 8. fetch the first page again
+        fake_time.time.return_value = 1640000000
+        local_actions = manager.query_actions_by_address("eth", "eth", "address_a")
+        self.assertEqual(
+            txids[:20],
+            [i.txid for i in local_actions],
+        )
+        self.assertEqual(501, models.TxAction.select().count())
+        fake_time.time.assert_called_once()
+        fake_provider_manager.search_txs_by_address.assert_called_once_with(
+            "eth", "address_a", paginate=provider_data.TxPaginate(start_block_number=298, items_per_page=200)
+        )
+        fake_time.time.reset_mock()
+        fake_provider_manager.verify_address.reset_mock()
+        fake_provider_manager.search_txs_by_address.reset_mock()
+
+        # 9. fetch the following 9 pages without network
+        for page_number in range(2, 11):
+            local_actions.extend(manager.query_actions_by_address("eth", "eth", "address_a", page_number=page_number))
+
+        self.assertEqual(501, models.TxAction.select().count())
+        self.assertEqual(200, len(local_actions))
+        self.assertEqual(txids[:200], [i.txid for i in local_actions])
+        fake_time.time.assert_not_called()
+        fake_provider_manager.search_txs_by_address.assert_not_called()
+
+        # 10. fetch the remaining txs between 298 to 400
+        local_actions.extend(manager.query_actions_by_address("eth", "eth", "address_a", page_number=11))
+
+        self.assertEqual(600, models.TxAction.select().count())
+        self.assertEqual(txids[:220], [i.txid for i in local_actions])
+        fake_time.time.assert_not_called()
+        fake_provider_manager.search_txs_by_address.assert_called_once_with(
+            "eth",
+            "address_a",
+            paginate=provider_data.TxPaginate(start_block_number=298, end_block_number=400, items_per_page=200),
+        )
+        fake_provider_manager.search_txs_by_address.reset_mock()
+
+        # 11. fetch the following all pages
+        for page_number in range(12, 31):
+            local_actions.extend(manager.query_actions_by_address("eth", "eth", "address_a", page_number=page_number))
+
+        self.maxDiff = None
+        self.assertEqual(600, models.TxAction.select().count())
+        self.assertEqual(600, len(local_actions))
+        self.assertEqual(txids, [i.txid for i in local_actions])
+        fake_time.time.assert_not_called()
+        fake_provider_manager.search_txs_by_address.assert_not_called()
+
+        # 12. nothing anymore
+        local_actions.extend(manager.query_actions_by_address("eth", "eth", "address_a", page_number=31))
+        self.assertEqual(600, models.TxAction.select().count())
+        self.assertEqual(600, len(local_actions))
+        fake_provider_manager.search_txs_by_address.assert_called_once_with(
+            'eth',
+            'address_a',
+            paginate=provider_data.TxPaginate(end_block_number=0, page_number=1, items_per_page=200),
+        )
+        fake_provider_manager.search_txs_by_address.reset_mock()
+
+        # 13. check searching_address_as argument
+        fake_time.time.return_value = 1650000000
+        self.assertEqual(
+            [i for i in txids if "from" in i],
+            [
+                i.txid
+                for i in manager.query_actions_by_address(
+                    "eth", "eth", "address_a", searching_address_as="sender", items_per_page=600
+                )
+            ],
+        )
+        fake_provider_manager.search_txs_by_address.assert_has_calls(
+            [
+                call(
+                    'eth',
+                    'address_a',
+                    paginate=provider_data.TxPaginate(start_block_number=598, page_number=1, items_per_page=200),
+                ),
+                call(
+                    'eth',
+                    'address_a',
+                    paginate=provider_data.TxPaginate(end_block_number=0, page_number=1, items_per_page=400),
+                ),
+            ]
+        )
+        fake_provider_manager.search_txs_by_address.reset_mock()
+
+        fake_time.time.return_value = 1660000000
+        self.assertEqual(
+            [i for i in txids if "to" in i],
+            [
+                i.txid
+                for i in manager.query_actions_by_address(
+                    "eth", "eth", "address_a", searching_address_as="receiver", items_per_page=600
+                )
+            ],
+        )
+        fake_provider_manager.search_txs_by_address.assert_has_calls(
+            [
+                call(
+                    'eth',
+                    'address_a',
+                    paginate=provider_data.TxPaginate(start_block_number=598, page_number=1, items_per_page=200),
+                ),
+                call(
+                    'eth',
+                    'address_a',
+                    paginate=provider_data.TxPaginate(end_block_number=0, page_number=1, items_per_page=400),
+                ),
+            ]
+        )
+
+    @patch("electrum_gui.common.transaction.manager.provider_manager")
+    @patch("electrum_gui.common.transaction.manager.coin_manager")
+    @patch("electrum_gui.common.transaction.manager.time")
+    def test_query_actions_by_address_check_max_times(self, fake_time, fake_coin_manager, fake_provider_manager):
+        fake_time.time.return_value = 1610000000
+        fake_coin_manager.get_chain_info.return_value = Mock(chain_model=coin_data.ChainModel.ACCOUNT)
+        fake_coin_manager.get_coin_info.return_value = Mock(code="eth")
+        fake_coin_manager.query_coins_by_token_addresses.return_value = []
+        fake_provider_manager.verify_address.side_effect = lambda chain_code, address: Mock(normalized_address=address)
+
+        txs = [
             provider_data.Transaction(
-                txid="txid_a",
+                txid=f"txid_from_a_{i}",
                 status=provider_data.TransactionStatus.CONFIRM_SUCCESS,
-                inputs=[
-                    provider_data.TransactionInput(address="address_a", value=0),
-                    provider_data.TransactionInput(address="address_a", value=2100, token_address="contract_a"),
-                ],
-                outputs=[
-                    provider_data.TransactionOutput(address="contract_a", value=0),
-                    provider_data.TransactionOutput(address="address_b", value=2100, token_address="contract_a"),
-                ],
+                inputs=[provider_data.TransactionInput(address="address_a", value=10)],
+                outputs=[provider_data.TransactionOutput(address="address_b", value=10)],
                 fee=provider_data.TransactionFee(limit=1000, used=900, price_per_unit=20),
                 block_header=provider_data.BlockHeader(
-                    block_hash="block_a", block_number=1001, block_time=1600000000, confirmations=3
+                    block_number=1000 + i, block_time=1600000000 + i, block_hash=f"block_{i}"
                 ),
-                nonce=3,
+                nonce=i,
             )
+            for i in range(10)
         ]
-        fake_provider_manager.search_txs_by_address.return_value = fake_txs
+        fake_provider_manager.search_txs_by_address.side_effect = lambda *args, **kwargs: [txs.pop()] if txs else []
 
-        with self.subTest("First time"):
-            manager.sync_address_actions("eth", "address_a")
-
-            txns = list(models.TxAction.select().order_by(models.TxAction.id.asc()))
-            self.assertEqual(2, len(txns))
-            self.assertEqual(
-                [
-                    {
-                        "id": 1,
-                        "txid": "txid_a",
-                        "status": models.TxActionStatus.CONFIRM_SUCCESS,
-                        "chain_code": "eth",
-                        "coin_code": "eth",
-                        "value": decimal.Decimal(0),
-                        "decimals": 18,
-                        "from_address": "address_a",
-                        "to_address": "contract_a",
-                        "fee_limit": decimal.Decimal(1000),
-                        "fee_used": decimal.Decimal(900),
-                        "fee_price_per_unit": decimal.Decimal(20),
-                        "block_number": 1001,
-                        "block_hash": "block_a",
-                        "block_time": 1600000000,
-                        "index": 0,
-                        "nonce": 3,
-                    },
-                    {
-                        "id": 2,
-                        "txid": "txid_a",
-                        "status": models.TxActionStatus.CONFIRM_SUCCESS,
-                        "chain_code": "eth",
-                        "coin_code": "eth_usdt",
-                        "value": decimal.Decimal(2100),
-                        "decimals": 6,
-                        "from_address": "address_a",
-                        "to_address": "address_b",
-                        "fee_limit": decimal.Decimal(1000),
-                        "fee_used": decimal.Decimal(900),
-                        "fee_price_per_unit": decimal.Decimal(20),
-                        "block_number": 1001,
-                        "block_hash": "block_a",
-                        "block_time": 1600000000,
-                        "index": 1,
-                        "nonce": -1,
-                    },
-                ],
-                [
-                    {
-                        "id": i.id,
-                        "txid": i.txid,
-                        "status": i.status,
-                        "chain_code": i.chain_code,
-                        "coin_code": i.coin_code,
-                        "value": i.value,
-                        "decimals": i.decimals,
-                        "from_address": i.from_address,
-                        "to_address": i.to_address,
-                        "fee_limit": i.fee_limit,
-                        "fee_used": i.fee_used,
-                        "fee_price_per_unit": i.fee_price_per_unit,
-                        "block_number": i.block_number,
-                        "block_hash": i.block_hash,
-                        "block_time": i.block_time,
-                        "index": i.index,
-                        "nonce": i.nonce,
-                    }
-                    for i in txns
-                ],
-            )
-            fake_provider_manager.search_txs_by_address.assert_called_once_with("eth", "address_a", paginate=None)
-            fake_provider_manager.search_txs_by_address.reset_mock()
-
-        with self.subTest("Second time"):
-            fake_txs = [
-                provider_data.Transaction(
-                    txid="txid_b",
-                    status=provider_data.TransactionStatus.PENDING,
-                    inputs=[provider_data.TransactionInput(address="address_a", value=11)],
-                    outputs=[provider_data.TransactionOutput(address="contract_c", value=11)],
-                    fee=provider_data.TransactionFee(limit=20000, used=1999, price_per_unit=20),
-                    nonce=4,
-                ),
-                *fake_txs,
+        local_actions = manager.query_actions_by_address("eth", "eth", "address_a")
+        self.assertEqual(["txid_from_a_9", "txid_from_a_8", "txid_from_a_7"], [i.txid for i in local_actions])
+        fake_time.time.assert_called_once()
+        fake_provider_manager.search_txs_by_address.assert_has_calls(
+            [
+                call("eth", "address_a", paginate=provider_data.TxPaginate(items_per_page=200)),
+                call("eth", "address_a", paginate=provider_data.TxPaginate(end_block_number=1009, items_per_page=400)),
+                call("eth", "address_a", paginate=provider_data.TxPaginate(end_block_number=1008, items_per_page=800)),
             ]
-            fake_provider_manager.search_txs_by_address.return_value = fake_txs
-
-            manager.sync_address_actions("eth", "address_a")
-            txns = list(models.TxAction.select().order_by(models.TxAction.id.asc()))
-            self.assertEqual(3, len(txns))
-            last_one = txns[-1]
-            self.assertEqual(
-                {
-                    "id": 3,
-                    "txid": "txid_b",
-                    "status": models.TxActionStatus.PENDING,
-                    "chain_code": "eth",
-                    "coin_code": "eth",
-                    "value": decimal.Decimal(11),
-                    "decimals": 18,
-                    "from_address": "address_a",
-                    "to_address": "contract_c",
-                    "fee_limit": decimal.Decimal(20000),
-                    "fee_used": decimal.Decimal(0),
-                    "fee_price_per_unit": decimal.Decimal(20),
-                    "block_number": None,
-                    "block_hash": None,
-                    "block_time": None,
-                    "index": 0,
-                    "nonce": 4,
-                },
-                {
-                    "id": last_one.id,
-                    "txid": last_one.txid,
-                    "status": last_one.status,
-                    "chain_code": last_one.chain_code,
-                    "coin_code": last_one.coin_code,
-                    "value": last_one.value,
-                    "decimals": last_one.decimals,
-                    "from_address": last_one.from_address,
-                    "to_address": last_one.to_address,
-                    "fee_limit": last_one.fee_limit,
-                    "fee_used": last_one.fee_used,
-                    "fee_price_per_unit": last_one.fee_price_per_unit,
-                    "block_number": last_one.block_number,
-                    "block_hash": last_one.block_hash,
-                    "block_time": last_one.block_time,
-                    "index": last_one.index,
-                    "nonce": last_one.nonce,
-                },
-            )
-            fake_provider_manager.search_txs_by_address.assert_called_once_with(
-                "eth", "address_a", paginate=provider_data.TxPaginate(start_block_number=1001)
-            )
+        )

--- a/electrum_gui/common/the_begging.py
+++ b/electrum_gui/common/the_begging.py
@@ -16,8 +16,10 @@ def initialize():
     # example ticker.signals.ticker_signal.connect(my_ticker_callback)
     from electrum_gui.common.basic import ticker
     from electrum_gui.common.price import manager as price_manager
+    from electrum_gui.common.transaction import manager as transaction_manager
 
     ticker.signals.ticker_signal.connect(price_manager.on_ticker_signal)
+    ticker.signals.ticker_signal.connect(transaction_manager.on_ticker_signal)
 
     # start ticker
     ticker.start_default_ticker(seconds=60)  # every 1 min

--- a/electrum_gui/common/transaction/daos.py
+++ b/electrum_gui/common/transaction/daos.py
@@ -200,11 +200,12 @@ def get_action_by_id(action_id: int) -> Optional[TxAction]:
 def query_actions_by_status(
     status: TxActionStatus,
     chain_code: str = None,
+    address: str = None,
 ) -> List[TxAction]:
     expressions = [TxAction.status == status]
 
-    if chain_code is not None:
-        expressions.append(TxAction.chain_code == chain_code)
+    chain_code is None or expressions.append(TxAction.chain_code == chain_code)
+    address is None or expressions.append(TxAction.from_address == address or TxAction.to_address == address)
 
     models = TxAction.select().where(*expressions)
     return list(models)

--- a/electrum_gui/common/transaction/daos.py
+++ b/electrum_gui/common/transaction/daos.py
@@ -1,6 +1,7 @@
 import datetime
+import functools
 from decimal import Decimal
-from typing import Iterable, List, Optional, Set
+from typing import Iterable, List, Literal, Optional, Set
 
 from electrum_gui.common.transaction.data import TxActionStatus
 from electrum_gui.common.transaction.models import TxAction
@@ -12,8 +13,6 @@ def new_action(
     chain_code: str,
     coin_code: str,
     value: Decimal,
-    symbol: str,
-    decimals: int,
     from_address: str,
     to_address: str,
     fee_limit: Decimal,
@@ -25,15 +24,14 @@ def new_action(
     block_time: int = None,
     index: int = 0,
     nonce: int = -1,
+    created_time: datetime.datetime = None,
 ) -> TxAction:
-    return TxAction(
+    data = dict(
         txid=txid,
         status=status,
         chain_code=chain_code,
         coin_code=coin_code,
         value=value,
-        symbol=symbol,
-        decimals=decimals,
         from_address=from_address,
         to_address=to_address,
         fee_limit=fee_limit,
@@ -46,6 +44,10 @@ def new_action(
         index=index,
         nonce=nonce,
     )
+    if created_time is not None:
+        data["created_time"] = created_time
+
+    return TxAction(**data)
 
 
 def bulk_create(actions: Iterable[TxAction]):
@@ -60,6 +62,7 @@ def on_actions_confirmed(
     block_number: int,
     block_hash: str,
     block_time: int,
+    archived_id: int = None,
 ):
     return (
         TxAction.update(
@@ -68,6 +71,7 @@ def on_actions_confirmed(
             block_number=block_number,
             block_hash=block_hash,
             block_time=block_time,
+            archived_id=archived_id,
             modified_time=datetime.datetime.now(),
         )
         .where(TxAction.chain_code == chain_code, TxAction.txid == txid)
@@ -93,23 +97,99 @@ def update_actions_status(
 def query_actions_by_address(
     chain_code: str,
     address: str,
-    txid: Optional[str] = None,
+    coin_code: str = None,
     page_number: int = 1,
-    items_per_page: int = 100,
+    items_per_page: int = 20,
+    archived_ids: List[int] = None,
+    searching_address_as: Literal["sender", "receiver", "both"] = "both",
 ) -> List[TxAction]:
+    address_query_expression_options = (
+        TxAction.from_address == address,
+        TxAction.to_address == address,
+    )
+
+    if searching_address_as == "sender":
+        address_query_expression = address_query_expression_options[0]
+    elif searching_address_as == "receiver":
+        address_query_expression = address_query_expression_options[1]
+    else:
+        address_query_expression = address_query_expression_options[0] | address_query_expression_options[1]
+
     expressions = [
         TxAction.chain_code == chain_code,
-        (TxAction.from_address.collate("NOCASE") == address) | (TxAction.to_address.collate("NOCASE") == address),
+        address_query_expression,
     ]
 
-    if txid is not None:
-        expressions.append(TxAction.txid == txid)
+    coin_code is None or expressions.append(TxAction.coin_code == coin_code)
+    not archived_ids or expressions.append(
+        functools.reduce(lambda a, b: a | b, (TxAction.archived_id == i for i in archived_ids))
+    )
 
-    return list(
+    actions = TxAction.select().where(*expressions).order_by(TxAction.created_time.desc())
+    if page_number is not None and items_per_page is not None:
+        actions = actions.paginate(page_number, items_per_page)
+
+    return list(actions)
+
+
+def get_first_confirmed_action_at_the_same_archived_id(
+    chain_code: str, address: str, archived_id: int
+) -> Optional[TxAction]:
+    return (
         TxAction.select()
-        .where(*expressions)
-        .order_by(TxAction.block_time.desc(nulls="first"))
-        .paginate(page_number, items_per_page)
+        .where(
+            TxAction.chain_code == chain_code,
+            (TxAction.from_address == address) | (TxAction.to_address == address),
+            TxAction.block_number != None,  # noqa
+            TxAction.archived_id == archived_id,
+        )
+        .order_by(TxAction.block_number.asc())
+        .first()
+    )
+
+
+def get_last_confirmed_action_before_archived_id(chain_code: str, address: str, archived_id: int) -> Optional[TxAction]:
+    return (
+        TxAction.select()
+        .where(
+            TxAction.chain_code == chain_code,
+            (TxAction.from_address == address) | (TxAction.to_address == address),
+            TxAction.block_number != None,  # noqa
+            TxAction.archived_id < archived_id,
+        )
+        .order_by(TxAction.archived_id.desc(), TxAction.block_number.desc())
+        .first()
+    )
+
+
+def query_existing_archived_ids(chain_code: str, txids: List[str]) -> Set[int]:
+    items = (
+        TxAction.select(TxAction.archived_id.distinct())
+        .where(
+            TxAction.chain_code == chain_code,
+            TxAction.txid.in_(txids),
+            TxAction.archived_id != None,  # noqa
+        )
+        .tuples()
+    )
+    return {i[0] for i in items}
+
+
+def filter_existing_txids(chain_code: str, txids: List[str], status: TxActionStatus = None) -> Set[str]:
+    expressions = [TxAction.chain_code == chain_code, TxAction.txid.in_(txids)]
+
+    if status is not None:
+        expressions.append(TxAction.status == status)
+
+    items = TxAction.select(TxAction.txid.distinct()).where(*expressions).tuples()
+    return {i[0] for i in items}
+
+
+def update_archived_id(from_archived_ids: List[int], archived_id: int) -> int:
+    return (
+        TxAction.update(archived_id=archived_id, modified_time=datetime.datetime.now())
+        .where(TxAction.archived_id.in_(from_archived_ids))
+        .execute()
     )
 
 
@@ -128,24 +208,3 @@ def query_actions_by_status(
 
     models = TxAction.select().where(*expressions)
     return list(models)
-
-
-def get_last_confirmed_action_by_address(chain_code: str, address: str) -> Optional[TxAction]:
-    return (
-        TxAction.select()
-        .where(
-            TxAction.chain_code == chain_code,
-            TxAction.block_time.is_null(False),
-            (TxAction.from_address.collate("NOCASE") == address) | (TxAction.to_address.collate("NOCASE") == address),
-        )
-        .order_by(TxAction.block_time.desc())
-        .first()
-    )
-
-
-def filter_existing_txids(chain_code: str, txids: Iterable[str]) -> Set[str]:
-    models = TxAction.select().where(
-        TxAction.chain_code == chain_code,
-        TxAction.txid << txids,
-    )
-    return {i.txid for i in models}

--- a/electrum_gui/common/transaction/data.py
+++ b/electrum_gui/common/transaction/data.py
@@ -5,13 +5,13 @@ from electrum_gui.common.provider.data import TransactionStatus
 
 @unique
 class TxActionStatus(IntEnum):
-    UNEXPECTED_FAILED = -2
-    UNKNOWN = -1
-    SIGNED = 9
-    PENDING = 10
-    REPLACED = 20
-    CONFIRM_REVERTED = 99
-    CONFIRM_SUCCESS = 100
+    UNEXPECTED_FAILED = -99
+    REPLACED = -10
+    SIGNED = -1
+    UNKNOWN = 0
+    PENDING = 1
+    CONFIRM_REVERTED = 2
+    CONFIRM_SUCCESS = 3
 
     @classmethod
     def to_choices(cls):

--- a/electrum_gui/common/transaction/manager.py
+++ b/electrum_gui/common/transaction/manager.py
@@ -7,6 +7,7 @@ from typing import Iterable, List, Literal, Optional, Tuple
 
 from electrum_gui.common.basic.functional.timing import timing_logger
 from electrum_gui.common.basic.orm.database import db
+from electrum_gui.common.basic.ticker.utils import on_interval
 from electrum_gui.common.coin import manager as coin_manager
 from electrum_gui.common.coin.data import ChainModel
 from electrum_gui.common.provider import provider_manager
@@ -56,8 +57,8 @@ def update_action_status(
     daos.update_actions_status(chain_code, txid, status)
 
 
-def update_pending_actions(chain_code: Optional[str] = None):
-    pending_actions = daos.query_actions_by_status(TxActionStatus.PENDING, chain_code=chain_code)
+def update_pending_actions(chain_code: Optional[str] = None, address: Optional[str] = None):
+    pending_actions = daos.query_actions_by_status(TxActionStatus.PENDING, chain_code=chain_code, address=address)
 
     if not pending_actions:
         return
@@ -320,3 +321,9 @@ def _sync_actions_by_address(chain_code: str, address: str, archived_id: int, re
             expand_count += len(to_be_created_actions)
 
     return expand_count
+
+
+@on_interval(60)
+@timing_logger("transaction_manager.on_ticker_signal")
+def on_ticker_signal():
+    update_pending_actions()

--- a/electrum_gui/common/transaction/manager.py
+++ b/electrum_gui/common/transaction/manager.py
@@ -1,9 +1,11 @@
 import datetime
 import itertools
 import logging
+import time
 from decimal import Decimal
-from typing import Iterable, List, Optional, Tuple
+from typing import Iterable, List, Literal, Optional, Tuple
 
+from electrum_gui.common.basic.functional.timing import timing_logger
 from electrum_gui.common.basic.orm.database import db
 from electrum_gui.common.coin import manager as coin_manager
 from electrum_gui.common.coin.data import ChainModel
@@ -28,15 +30,12 @@ def create_action(
     raw_tx: str,
     **kwargs,
 ) -> TxAction:
-    coin = coin_manager.get_coin_info(coin_code)
     return daos.new_action(
         txid=txid,
         status=status,
         chain_code=chain_code,
         coin_code=coin_code,
         value=value,
-        decimals=coin.decimals,
-        symbol=coin.symbol,
         from_address=from_address,
         to_address=to_address,
         fee_limit=fee_limit,
@@ -55,18 +54,6 @@ def update_action_status(
     status: TxActionStatus,
 ):
     daos.update_actions_status(chain_code, txid, status)
-
-
-def query_actions_by_address(
-    chain_code: str,
-    address: str,
-    txid: Optional[str] = None,
-    page_number: int = 1,
-    items_per_page: int = 100,
-) -> List[TxAction]:
-    return daos.query_actions_by_address(
-        chain_code, address, txid=txid, page_number=page_number, items_per_page=items_per_page
-    )
 
 
 def update_pending_actions(chain_code: Optional[str] = None):
@@ -171,8 +158,6 @@ def _tx_action_factory__account_model(chain_code: str, transactions: Iterable[Tr
                 chain_code=chain_code,
                 coin_code=coin.code,
                 value=Decimal(tx_output.value),
-                symbol=coin.symbol,
-                decimals=coin.decimals,
                 from_address=tx_input.address,
                 to_address=tx_output.address,
                 fee_limit=Decimal(tx.fee.limit),
@@ -188,10 +173,13 @@ def _tx_action_factory__account_model(chain_code: str, transactions: Iterable[Tr
                         block_number=tx.block_header.block_number,
                         block_hash=tx.block_header.block_hash,
                         block_time=tx.block_header.block_time,
+                        created_time=datetime.datetime.fromtimestamp(
+                            tx.block_header.block_time
+                        ),  # Unify the ordering of local records and on-chain transactions
                     )
                 )
 
-            if index == 0 and tx.nonce is not None and tx.nonce >= 0:
+            if tx.nonce is not None and tx.nonce >= 0:
                 info["nonce"] = tx.nonce
 
             yield daos.new_action(**info)
@@ -202,31 +190,133 @@ _TX_ACTION_FACTORY_REGISTRY = {
 }
 
 
-def sync_address_actions(chain_code: str, address: str, force_update: bool = False):
+def _search_actions_from_provider_by_address(
+    chain_code: str, address: str, paginate: TxPaginate = None
+) -> List[TxAction]:
     chain_info = coin_manager.get_chain_info(chain_code)
     action_factory = _TX_ACTION_FACTORY_REGISTRY.get(chain_info.chain_model)
+
     if not action_factory:
-        raise Exception(
-            f"This chain model isn't supported yet. "
-            f"chain_code: {chain_code}, chain_model: {repr(chain_info.chain_model)}"
+        return []
+
+    try:
+        transactions = provider_manager.search_txs_by_address(chain_code, address, paginate=paginate)
+    except Exception as e:
+        transactions = []
+        logger.exception(
+            f"Error in searching txs by address form provider. "
+            f"chain_code: {chain_code}, address: {address}, paginate: {paginate}",
+            e,
         )
 
-    if not force_update:
-        last_confirmed_action = daos.get_last_confirmed_action_by_address(chain_code, address)
-    else:
-        last_confirmed_action = None
+    transactions = (i for i in transactions if i.status in TX_TO_ACTION_STATUS_DIRECT_MAPPING)
+    actions = action_factory(chain_code, transactions)
+    actions = [i for i in actions if i.from_address == address or i.to_address == address]
+    return actions
 
-    raw_txs = _search_txs_by_address(chain_code, address, last_confirmed_action=last_confirmed_action)
-    raw_txs = (i for i in raw_txs if i.status in TX_TO_ACTION_STATUS_DIRECT_MAPPING)
-    txs = {i.txid: i for i in raw_txs}
 
-    txids = set(txs.keys())
-    existing_txids = daos.filter_existing_txids(chain_code, txids)
-    syncing_txids = txids - existing_txids
+_LAST_ARCHIVED_ID_CACHE = {}
 
-    if not syncing_txids:
-        return
 
+@timing_logger("transaction_manager.query_actions_by_address")
+def query_actions_by_address(
+    chain_code: str,
+    coin_code: str,
+    address: str,
+    page_number: int = 1,
+    items_per_page: int = 20,
+    searching_address_as: Literal["sender", "receiver", "both"] = "both",
+) -> List[TxAction]:
+    address = provider_manager.verify_address(chain_code, address).normalized_address
+    page_number = max(page_number, 1)
+    is_first_page = page_number == 1
+
+    archived_id_cache_key = f"{chain_code}:{address}"
+    archived_id = _LAST_ARCHIVED_ID_CACHE.get(archived_id_cache_key)
+    if is_first_page or not archived_id:
+        archived_id = int(time.time())
+        _LAST_ARCHIVED_ID_CACHE[archived_id_cache_key] = archived_id
+
+    local_actions = []
+    max_times = 3
+    for times in range(max_times + 1):
+        local_actions = daos.query_actions_by_address(
+            chain_code,
+            address,
+            coin_code=coin_code,
+            items_per_page=items_per_page,
+            page_number=page_number,
+            archived_ids=[archived_id, None],
+            searching_address_as=searching_address_as,
+        )
+
+        if (
+            len(local_actions) >= items_per_page
+            or times == max_times  # No need to invoke synchronization the last time
+            or _sync_actions_by_address(chain_code, address, archived_id, require_sync_number=200 * 1 << times) == 0
+        ):
+            break
+
+    return local_actions
+
+
+def _sync_actions_by_address(chain_code: str, address: str, archived_id: int, require_sync_number: int = 200) -> int:
+    first_confirmed_action = daos.get_first_confirmed_action_at_the_same_archived_id(chain_code, address, archived_id)
+    last_confirmed_action_before_this_archived = daos.get_last_confirmed_action_before_archived_id(
+        chain_code, address, archived_id
+    )
+
+    paginate = TxPaginate(
+        start_block_number=(
+            max(
+                0, last_confirmed_action_before_this_archived.block_number - 1
+            )  # Ensure that the requested block overlaps the recorded block
+            if last_confirmed_action_before_this_archived
+            else None
+        ),
+        end_block_number=first_confirmed_action.block_number if first_confirmed_action else None,
+        items_per_page=require_sync_number,
+    )
+    syncing_actions = _search_actions_from_provider_by_address(chain_code, address, paginate)
+    syncing_txids = list({i.txid for i in syncing_actions})
+
+    pending_txids = daos.filter_existing_txids(chain_code, syncing_txids, status=TxActionStatus.PENDING)
+    to_be_confirmed_actions = {
+        i.txid: i for i in syncing_actions if i.txid in pending_txids and i.block_number is not None
+    }
+
+    old_archived_ids = daos.query_existing_archived_ids(chain_code, syncing_txids)
+    if archived_id in old_archived_ids:
+        old_archived_ids.remove(archived_id)
+
+    existing_txids = daos.filter_existing_txids(chain_code, syncing_txids)
+    to_be_created_actions = [i for i in syncing_actions if i.txid not in existing_txids]
+
+    expand_count = 0
     with db.atomic():
-        actions = action_factory(chain_code, (i for i in txs.values() if i.txid in syncing_txids))
-        daos.bulk_create(actions)
+        if to_be_confirmed_actions:
+            for txid, action in to_be_confirmed_actions.items():
+                daos.on_actions_confirmed(
+                    chain_code=chain_code,
+                    txid=txid,
+                    status=action.status,
+                    fee_used=action.fee_used,
+                    block_hash=action.block_hash,
+                    block_number=action.block_number,
+                    block_time=action.block_time,
+                    archived_id=archived_id,
+                )
+
+            expand_count += len(to_be_confirmed_actions)
+
+        if old_archived_ids:
+            expand_count += daos.update_archived_id(list(old_archived_ids), archived_id)
+
+        if to_be_created_actions:
+            for i in to_be_created_actions:
+                i.archived_id = archived_id
+
+            daos.bulk_create(to_be_created_actions)
+            expand_count += len(to_be_created_actions)
+
+    return expand_count

--- a/electrum_gui/common/transaction/migrations/0002_txaction_delete_symbol_and_decimals.py
+++ b/electrum_gui/common/transaction/migrations/0002_txaction_delete_symbol_and_decimals.py
@@ -1,0 +1,5 @@
+def update(db, migrator, migrate):
+    migrate(
+        migrator.drop_column("txaction", "symbol"),
+        migrator.drop_column("txaction", "decimals"),
+    )

--- a/electrum_gui/common/transaction/migrations/0003_txaction_add_archived_id.py
+++ b/electrum_gui/common/transaction/migrations/0003_txaction_add_archived_id.py
@@ -1,0 +1,7 @@
+import peewee
+
+
+def update(db, migrator, migrate):
+    migrate(
+        migrator.add_column("txaction", "archived_id", peewee.IntegerField(null=True)),
+    )

--- a/electrum_gui/common/transaction/models.py
+++ b/electrum_gui/common/transaction/models.py
@@ -11,8 +11,6 @@ class TxAction(BaseModel):
     chain_code = peewee.CharField()
     coin_code = peewee.CharField()
     value = peewee.DecimalField(max_digits=32, decimal_places=0)
-    decimals = peewee.IntegerField()
-    symbol = peewee.CharField()
     from_address = peewee.CharField(index=True)
     to_address = peewee.CharField(index=True)
     fee_limit = peewee.DecimalField(max_digits=32, decimal_places=0)
@@ -24,15 +22,15 @@ class TxAction(BaseModel):
     block_time = peewee.IntegerField(null=True)
     index = peewee.IntegerField(default=0, help_text="action index of the transaction")
     nonce = peewee.IntegerField(default=-1, help_text="a special field of the nonce model, likes eth")
+    archived_id = peewee.IntegerField(null=True)
     created_time = AutoDateTimeField()
     modified_time = AutoDateTimeField()
 
     def __str__(self):
-        value_in_decimals = self.value / pow(10, self.decimals)
         return (
             f"id: {self.id}, coin_code: {self.coin_code}, "
-            f"action: <from {self.from_address} to {self.to_address} for {value_in_decimals} {self.symbol}>, "
-            f"status: {self.status}, txid: {self.txid}"
+            f"from_address: {self.from_address}, to_address: {self.to_address}, "
+            f"value: {self.value}, status: {self.status}, txid: {self.txid}"
         )
 
     class Meta:


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
1. 更新 transaction 模块实现，更好地处理同步
2. 迁移 get_general_coin_tx_list 实现
3. get_tx_info 适配 GeneralWallet
4. 自动刷新 Pending 交易

以下简单解释下 query_actions_by_address 的实现：
1. 每次获取第一页数据时都会为地址分配一个 `归档 ID`。同一个归档 ID 标记的交易记录可认为是连续的（即该区块段里的交易是完全同步的）
2. 现在搜索地址 A 的交易记录，先为它分配个归档 ID（目前用当前时间戳做归档 ID）
3. 因为本地没有交易记录，所以会去链上获取前200个交易，然后保存到 DB，并为他们设置相同的归档 ID（假设交易的区块号从 10000 - 11000）
4. 目前分页是 20 一页，所以用户在后续的 9 页都不会请求网络，而是直接从 DB 获取
5. 当用户滑到最底部后，因为本地没有更多记录了，又需要去请求链上，此时会从最后区块开始请求，即请求 10000 以前的200条交易记录
6. 假设又获取到从 800 到 1000 区块的交易记录，此时保存到数据库时依然为他们设置跟上面一样的归档 ID 。此时就有地址 A 从 800 - 11000 区块共 400 条连续的交易记录了
7. 如果用户继续往下翻页，依然可以按照上面的做法继续新增
8. 而如果用户过了一段时间后又产生了 300 条数据，想刷新下最新的数据
9. 因为是重新获取第一页，所以又用户分配个新的 `归档 ID`
10. 此时因为还没有任何一笔交易被这个新的归档 ID 标记过，但我们知道此前有 400 笔交易记录被之前的归档 ID 标记过了，而之前那个归档 ID 的最后一条记录在 1100 区块，所以会尝试获取从最新到 1099（1100 - 1，为了确保最终会出现交集） 区块的前 200 条记录，例如获取到了从 13000 到 12000 的交易记录，并给它们标记上新的归档 ID
11. 用户继续往下翻页，触底后又会获取从 1200 到 1099 的记录，此时就正好100多条记录（有部分记录是 1100 - 1099 区块的，有交集了）。此时我们在保存新的100条交易的同时，也会把原来旧归档 ID 标记的记录修改成新归档 ID。因此所有地址 A 的记录都被新归档 ID 标记了，也说明从 1300 - 800 共 700 条记录都同步完全了


## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
…

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
…

## Any other comments?
…
