### PR TITLE
parse_address_v2: Fetch all chains without enabled check

### DIFF
--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -2109,7 +2109,7 @@ class AndroidCommands(commands.Commands):
         if not maybe_address:
             raise InvalidAddressURI(f"Address not found. data: {data}")
 
-        all_enabled_chains = coin_manager.get_all_chains(only_enabled=True)
+        all_enabled_chains = coin_manager.get_all_chains()
         selection = []
 
         def _remove_testnet_prefix(chain_code: str) -> str:


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
原本 settings.ENABLED_CHAIN_COINS 是为了做切换币种启用状态用的，但现在在加载时候就已经确认启用哪些币种了，所以这里就不需要检查 only_enabled 了

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
https://github.com/OneKeyHQ/TaskHub/issues/1904#issuecomment-869367659

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
…

## Any other comments?
…
