### PR TITLE
adjust  stc mainnet upgrade

### DIFF
--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -3281,7 +3281,7 @@ class AndroidCommands(commands.Commands):
         """
         Verify legality for seed/private/public/address
         :param data: data as string
-        :param falg: seed/private/public/address/keystore as string
+        :param flag: seed/private/public/address/keystore as string
         :param coin: btc/eth as string
         :return: raise except if failed
         """
@@ -3311,12 +3311,6 @@ class AndroidCommands(commands.Commands):
                 validation = provider_manager.verify_address(chain_code, data)
                 if not validation.is_valid:
                     raise exceptions.IncorrectAddress()
-                if (
-                    chain_affinity == "stc"
-                    and validation.encoding == "HEX"
-                    and not provider_manager.get_address(chain_code, data).existing
-                ):
-                    raise exceptions.InactiveAddress()
         elif chain_affinity == "btc":
             if flag == "private":
                 try:

--- a/electrum_gui/common/coin/configs/chains.json
+++ b/electrum_gui/common/coin/configs/chains.json
@@ -290,7 +290,8 @@
     "clients": [
       {
         "class": "STCJsonRPC",
-        "url": "https://main-seed.starcoin.org"
+        "url": "https://main-seed.starcoin.org",
+        "expire_interval": 120
       }
     ],
     "chain_affinity": "stc",

--- a/electrum_gui/common/coin/configs/testnet_chains.json
+++ b/electrum_gui/common/coin/configs/testnet_chains.json
@@ -197,7 +197,8 @@
     "clients": [
       {
         "class": "STCJsonRPC",
-        "url": "https://barnard-seed.starcoin.org"
+        "url": "https://barnard-seed.starcoin.org",
+        "expire_interval": 864000
       }
     ],
     "chain_affinity": "stc",

--- a/electrum_gui/common/provider/chains/stc/clients/jsonrpc.py
+++ b/electrum_gui/common/provider/chains/stc/clients/jsonrpc.py
@@ -37,8 +37,9 @@ class StateNotFoundError(ValueError):
 
 
 class STCJsonRPC(ClientInterface):
-    def __init__(self, url: str, timeout: int = 5):
+    def __init__(self, url: str, timeout: int = 5, expire_interval: int = 120):
         self.rpc = JsonRPCRequest(url=url, timeout=timeout)
+        self.expire_interval = expire_interval
 
     def get_info(self) -> ClientInfo:
         block_info = self.rpc.call("chain.info", params=[])
@@ -47,7 +48,7 @@ class STCJsonRPC(ClientInterface):
         return ClientInfo(
             "STC_JSON_RPC",
             best_block_number=int(block_number),
-            is_ready=int(time.time()) - block_time < 120,
+            is_ready=int(time.time()) - block_time < self.expire_interval,
         )
 
     def _get_account_sequence_number(self, addr: str) -> int:
@@ -124,7 +125,7 @@ class STCJsonRPC(ClientInterface):
             if isinstance(
                 _script_function_call,
                 (
-                    starcoin_stdlib.ScriptFunctionCall__PeerToPeer,
+                    starcoin_stdlib.ScriptFunctionCall__PeerToPeerV2,
                     # starcoin_stdlib.ScriptFunctionCall__AcceptToken, todo parse accept token tx
                 ),
             ):

--- a/electrum_gui/common/provider/chains/stc/sdk/starcoin_stdlib/__init__.py
+++ b/electrum_gui/common/provider/chains/stc/sdk/starcoin_stdlib/__init__.py
@@ -30,12 +30,11 @@ class ScriptFunctionCall__AcceptToken(ScriptFunctionCall):
 
 
 @dataclass(frozen=True)
-class ScriptFunctionCall__PeerToPeer(ScriptFunctionCall):
+class ScriptFunctionCall__PeerToPeerV2(ScriptFunctionCall):
     """."""
 
     token_type: starcoin_types.TypeTag
     payee: starcoin_types.AccountAddress
-    payee_auth_key: bytes
     amount: st.uint128
 
 
@@ -64,22 +63,17 @@ def encode_accept_token_script_function(token_type: TypeTag) -> TransactionPaylo
     )
 
 
-def encode_peer_to_peer_script_function(
-    token_type: TypeTag, payee: AccountAddress, payee_auth_key: bytes, amount: st.uint128
+def encode_peer_to_peer_v2_script_function(
+    token_type: TypeTag, payee: AccountAddress, amount: st.uint128
 ) -> TransactionPayload:
-    """."""
     return TransactionPayload__ScriptFunction(
         value=ScriptFunction(
             module=ModuleId(
                 address=AccountAddress.from_hex("00000000000000000000000000000001"), name=Identifier("TransferScripts")
             ),
-            function=Identifier("peer_to_peer"),
+            function=Identifier("peer_to_peer_v2"),
             ty_args=[token_type],
-            args=[
-                bcs.serialize(payee, starcoin_types.AccountAddress),
-                bcs.serialize(payee_auth_key, bytes),
-                bcs.serialize(amount, st.uint128),
-            ],
+            args=[bcs.serialize(payee, starcoin_types.AccountAddress), bcs.serialize(amount, st.uint128)],
         )
     )
 
@@ -92,18 +86,17 @@ def decode_accept_token_script_function(script: TransactionPayload) -> ScriptFun
     )
 
 
-def decode_peer_to_peer_script_function(script: TransactionPayload) -> ScriptFunctionCall:
+def decode_peer_to_peer_v2_script_function(script: TransactionPayload) -> ScriptFunctionCall:
     if not isinstance(script, ScriptFunction):
         raise ValueError("Unexpected transaction payload")
-    return ScriptFunctionCall__PeerToPeer(
+    return ScriptFunctionCall__PeerToPeerV2(
         token_type=script.ty_args[0],
         payee=bcs.deserialize(script.args[0], starcoin_types.AccountAddress),
-        payee_auth_key=bcs.deserialize(script.args[1], bytes),
-        amount=bcs.deserialize(script.args[2], st.uint128),
+        amount=bcs.deserialize(script.args[1], st.uint128),
     )
 
 
 SCRIPT_FUNCTION_DECODER_MAP: typing.Dict[str, typing.Callable[[TransactionPayload], ScriptFunctionCall]] = {
     "Accountaccept_token": decode_accept_token_script_function,
-    "TransferScriptspeer_to_peer": decode_peer_to_peer_script_function,
+    "TransferScriptspeer_to_peer_v2": decode_peer_to_peer_v2_script_function,
 }

--- a/electrum_gui/common/provider/manager.py
+++ b/electrum_gui/common/provider/manager.py
@@ -123,3 +123,7 @@ def get_token_info_by_address(chain_code: str, token_address: str) -> Tuple[str,
 
 def get_client_by_chain(chain_code: str, instance_required: Any = None) -> interfaces.ClientInterface:
     return loader.get_client_by_chain(chain_code, instance_required=instance_required)
+
+
+def get_provider_by_chain(chain_code: str) -> interfaces.ProviderInterface:
+    return loader.get_provider_by_chain(chain_code)

--- a/electrum_gui/common/tests/unit/provider/chains/stc/test_provider.py
+++ b/electrum_gui/common/tests/unit/provider/chains/stc/test_provider.py
@@ -62,7 +62,7 @@ class TestSTCProvider(TestCase):
         self.assertEqual(AddressValidation("", "", is_valid=False, encoding=None), self.provider.verify_address("0x"))
         self.assertEqual(
             AddressValidation(
-                "stc1pr9xnd0n9492jq8k8j9nt3r9p3cf88k6a7wtl9cyal2773ap3x6lpjnfkhej6j4fqrmreze4c3jscug7yx2e",
+                "0x194d36be65a955201ec79166b88ca18e",
                 "stc1pr9xnd0n9492jq8k8j9nt3r9p3cf88k6a7wtl9cyal2773ap3x6lpjnfkhej6j4fqrmreze4c3jscug7yx2e",
                 is_valid=True,
                 encoding="BECH32",
@@ -79,7 +79,7 @@ class TestSTCProvider(TestCase):
         )
         self.assertEqual(
             AddressValidation(
-                "stc1pr9xnd0n9492jq8k8j9nt3r9p3crvw030",
+                "0x194d36be65a955201ec79166b88ca18e",
                 "stc1pr9xnd0n9492jq8k8j9nt3r9p3crvw030",
                 is_valid=True,
                 encoding="BECH32",
@@ -169,8 +169,8 @@ class TestSTCProvider(TestCase):
         with self.subTest("Sign STC Transfer Tx with hex to_address"):
             self.assertEqual(
                 SignedTx(
-                    txid="0x55a8ab2df5db77e3be24304cc868f12fd35cb78e77842003d5f2aa17494adfd9",
-                    raw_tx="0xb61a35af603018441b06177a8820ff2a120000000000000002000000000000000000000000000000010f5472616e73666572536372697074730c706565725f746f5f706565720107000000000000000000000000000000010353544303535443000310194d36be65a955201ec79166b88ca18e01001000040000000000000000000000000000809698000000000001000000000000000d3078313a3a5354433a3a5354438a77a36000000000fb00207b945271879962dde59a0e170219d04a1c3ae3901de95041283c473902d0b03d40b4f0eb5b9994767f8e43885d4c50f5e066f14dee8c8c72bca1d717b392cb77d0738373e3bd1a7809c587afcbc8e31185bcdf0d288a63b01bca5eb7b713bed200",
+                    txid="0xa7c98d9742332150ef4e9214c7593b36cfa2fd981de0c44cf19d1704e2aaf245",
+                    raw_tx="0xb61a35af603018441b06177a8820ff2a120000000000000002000000000000000000000000000000010f5472616e73666572536372697074730f706565725f746f5f706565725f76320107000000000000000000000000000000010353544303535443000210194d36be65a955201ec79166b88ca18e1000040000000000000000000000000000809698000000000001000000000000000d3078313a3a5354433a3a5354438a77a36000000000fb00207b945271879962dde59a0e170219d04a1c3ae3901de95041283c473902d0b03d40b4f0eb5b9994767f8e43885d4c50f5e066f14dee8c8c72bca1d717b392cb77d0738373e3bd1a7809c587afcbc8e31185bcdf0d288a63b01bca5eb7b713bed200",
                 ),
                 self.provider.sign_transaction(
                     self.provider.fill_unsigned_tx(
@@ -187,43 +187,14 @@ class TestSTCProvider(TestCase):
                 ),
             )
 
-        with self.subTest("Sign STC Transfer Tx with existing ReceiptIdentifier"):
+        with self.subTest("Sign STC Transfer Tx with ReceiptIdentifier"):
             fake_client = Mock(
                 get_address=Mock(return_value=Mock(existing=True)),
             )
             self.assertEqual(
                 SignedTx(
-                    txid="0x55a8ab2df5db77e3be24304cc868f12fd35cb78e77842003d5f2aa17494adfd9",
-                    raw_tx="0xb61a35af603018441b06177a8820ff2a120000000000000002000000000000000000000000000000010f5472616e73666572536372697074730c706565725f746f5f706565720107000000000000000000000000000000010353544303535443000310194d36be65a955201ec79166b88ca18e01001000040000000000000000000000000000809698000000000001000000000000000d3078313a3a5354433a3a5354438a77a36000000000fb00207b945271879962dde59a0e170219d04a1c3ae3901de95041283c473902d0b03d40b4f0eb5b9994767f8e43885d4c50f5e066f14dee8c8c72bca1d717b392cb77d0738373e3bd1a7809c587afcbc8e31185bcdf0d288a63b01bca5eb7b713bed200",
-                ),
-                self.provider.sign_transaction(
-                    self.provider.fill_unsigned_tx(
-                        UnsignedTx(
-                            inputs=[TransactionInput(address="0xb61a35af603018441b06177a8820ff2a", value=1024)],
-                            outputs=[
-                                TransactionOutput(
-                                    address="stc1pr9xnd0n9492jq8k8j9nt3r9p3cf88k6a7wtl9cyal2773ap3x6lpjnfkhej6j4fqrmreze4c3jscug7yx2e",
-                                    value=1024,
-                                )
-                            ],
-                            nonce=18,
-                            fee_price_per_unit=1,
-                            fee_limit=10000000,
-                            payload={"expiration_time": 1621325706},
-                        ),
-                    ),
-                    signers,
-                ),
-            )
-
-        with self.subTest("Sign STC Transfer Tx with  a nonexistent ReceiptIdentifier"):
-            fake_client = Mock(
-                get_address=Mock(return_value=Mock(existing=False)),
-            )
-            self.assertEqual(
-                SignedTx(
-                    txid="0x4fe1184686c5d2270833a55fdbfb83e6551cb8c56452cc9ea58ff55c1277aac5",
-                    raw_tx="0xb61a35af603018441b06177a8820ff2a120000000000000002000000000000000000000000000000010f5472616e73666572536372697074730c706565725f746f5f706565720107000000000000000000000000000000010353544303535443000310194d36be65a955201ec79166b88ca18e21201273db5df397f2e09dfabde8f43136be194d36be65a955201ec79166b88ca18e1000040000000000000000000000000000809698000000000001000000000000000d3078313a3a5354433a3a5354438a77a36000000000fb00207b945271879962dde59a0e170219d04a1c3ae3901de95041283c473902d0b03d40b4f0eb5b9994767f8e43885d4c50f5e066f14dee8c8c72bca1d717b392cb77d0738373e3bd1a7809c587afcbc8e31185bcdf0d288a63b01bca5eb7b713bed200",
+                    txid="0xa7c98d9742332150ef4e9214c7593b36cfa2fd981de0c44cf19d1704e2aaf245",
+                    raw_tx="0xb61a35af603018441b06177a8820ff2a120000000000000002000000000000000000000000000000010f5472616e73666572536372697074730f706565725f746f5f706565725f76320107000000000000000000000000000000010353544303535443000210194d36be65a955201ec79166b88ca18e1000040000000000000000000000000000809698000000000001000000000000000d3078313a3a5354433a3a5354438a77a36000000000fb00207b945271879962dde59a0e170219d04a1c3ae3901de95041283c473902d0b03d40b4f0eb5b9994767f8e43885d4c50f5e066f14dee8c8c72bca1d717b392cb77d0738373e3bd1a7809c587afcbc8e31185bcdf0d288a63b01bca5eb7b713bed200",
                 ),
                 self.provider.sign_transaction(
                     self.provider.fill_unsigned_tx(


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
导入观察地址，需要将  receipt_identifier 转换为 hex格式地址
https://github.com/OneKeyHQ/TaskHub/issues/2149#issuecomment-871146646

主网转账协议有更新，使用v2协议， 不再检查地址是否激活。 去掉之前激活相关判断。

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
…

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
…

## Any other comments?
…
