### PR TITLE
OK-2694 Solve the problem of stc's read only wallet that reports an error when upgrading the password

### DIFF
--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -3804,7 +3804,8 @@ class AndroidCommands(commands.Commands):
         """
         self._assert_daemon_running()
         for _name, wallet in self.daemon._wallets.items():
-            wallet.update_password(old_pw=old_password, new_pw=new_password, str_pw=self.android_id)
+            if not wallet.is_watching_only():
+                wallet.update_password(old_pw=old_password, new_pw=new_password, str_pw=self.android_id)
 
     @api.api_entry()
     def check_password(self, password):


### PR DESCRIPTION


## What does this implement/fix? Explain your changes.
修复了ios下存在只读钱包的时候 升级密码提示“raising by require”的问题

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
https://onekeyhq.atlassian.net/browse/OK-2694

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
Python

## Any other comments?
…
