### PR TITLE
stc: support ScriptFunctionCall__PeerToPeerV1

### DIFF
--- a/electrum_gui/common/provider/chains/stc/clients/jsonrpc.py
+++ b/electrum_gui/common/provider/chains/stc/clients/jsonrpc.py
@@ -133,6 +133,7 @@ class STCJsonRPC(ClientInterface):
             if isinstance(
                 _script_function_call,
                 (
+                    starcoin_stdlib.ScriptFunctionCall__PeerToPeer,
                     starcoin_stdlib.ScriptFunctionCall__PeerToPeerV2,
                     # starcoin_stdlib.ScriptFunctionCall__AcceptToken, todo parse accept token tx
                 ),

--- a/electrum_gui/common/provider/chains/stc/sdk/starcoin_stdlib/__init__.py
+++ b/electrum_gui/common/provider/chains/stc/sdk/starcoin_stdlib/__init__.py
@@ -30,6 +30,16 @@ class ScriptFunctionCall__AcceptToken(ScriptFunctionCall):
 
 
 @dataclass(frozen=True)
+class ScriptFunctionCall__PeerToPeer(ScriptFunctionCall):
+    """."""
+
+    token_type: starcoin_types.TypeTag
+    payee: starcoin_types.AccountAddress
+    payee_auth_key: bytes
+    amount: st.uint128
+
+
+@dataclass(frozen=True)
 class ScriptFunctionCall__PeerToPeerV2(ScriptFunctionCall):
     """."""
 
@@ -86,6 +96,17 @@ def decode_accept_token_script_function(script: TransactionPayload) -> ScriptFun
     )
 
 
+def decode_peer_to_peer_script_function(script: TransactionPayload) -> ScriptFunctionCall:
+    if not isinstance(script, ScriptFunction):
+        raise ValueError("Unexpected transaction payload")
+    return ScriptFunctionCall__PeerToPeer(
+        token_type=script.ty_args[0],
+        payee=bcs.deserialize(script.args[0], starcoin_types.AccountAddress),
+        payee_auth_key=bcs.deserialize(script.args[1], bytes),
+        amount=bcs.deserialize(script.args[2], st.uint128),
+    )
+
+
 def decode_peer_to_peer_v2_script_function(script: TransactionPayload) -> ScriptFunctionCall:
     if not isinstance(script, ScriptFunction):
         raise ValueError("Unexpected transaction payload")
@@ -98,5 +119,6 @@ def decode_peer_to_peer_v2_script_function(script: TransactionPayload) -> Script
 
 SCRIPT_FUNCTION_DECODER_MAP: typing.Dict[str, typing.Callable[[TransactionPayload], ScriptFunctionCall]] = {
     "Accountaccept_token": decode_accept_token_script_function,
+    "TransferScriptspeer_to_peer": decode_peer_to_peer_script_function,
     "TransferScriptspeer_to_peer_v2": decode_peer_to_peer_v2_script_function,
 }


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
官方浏览器插件仍然继续使用的 ScriptFunctionCall__PeerToPeerV1。
decode 交易信息， 也需要支持。 避免解析不出完整数据。
应该不太紧急，可以放到下周发布。

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
…

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
python console

## Any other comments?
…
