### PR TITLE
mnemonic: remove unneeded import

### DIFF
--- a/electrum/mnemonic.py
+++ b/electrum/mnemonic.py
@@ -31,8 +31,6 @@ import string
 from typing import Sequence, Dict
 from types import MappingProxyType
 
-from idna import unicode
-
 from .util import resource_path, bfh, bh2u, randrange
 from .crypto import hmac_oneshot
 from . import version


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
清掉一个idna的import，idna新版本里没这个unicode的对象了，所以导致跑coverage的时候自动装上的是最新的idna的话就会报错。而这个unicode的import实际上又没被用到所以去掉就好。

P.S.: 在tox.ini里加上idna指定版本也能解决。

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
No

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): cleanup

## Where has this been tested?
Python

## Any other comments?
No