### PR TITLE
self.hw_info should not be cleared before creation

### DIFF
--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -2951,7 +2951,6 @@ class AndroidCommands(commands.Commands):
         :bip39_derivation: user defined path as string
         :return: xpub string
         """
-        self.hw_info.clear()
 
         if is_coin_migrated(coin):
             feature = hardware_manager.get_feature(path)


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
不能清除 hw_info, create_hw_derived_wallet 会调用两次 get_xpub_from_hw，self.hw_info 需要缓存第一次调用获取到的 xpub

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
…

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
…

## Any other comments?
…
