### PR TITLE
Ignore value of 'inSync' on BlockBook.get_info

### DIFF
--- a/electrum_gui/common/provider/chains/eth/clients/blockbook.py
+++ b/electrum_gui/common/provider/chains/eth/clients/blockbook.py
@@ -51,15 +51,13 @@ class BlockBook(ClientInterface, SearchTransactionMixin):
     def get_info(self) -> ClientInfo:
         resp = self.restful.get("/api/v2")
 
-        is_ready = resp["blockbook"].get("inSync") is True
-        if is_ready:
-            normalize_last_block_time = _normalize_iso_format(resp["blockbook"]["lastBlockTime"])
+        normalize_last_block_time = _normalize_iso_format(resp["blockbook"]["lastBlockTime"])
 
-            try:
-                last_block_time = datetime.datetime.fromisoformat(normalize_last_block_time).timestamp()
-                is_ready = time.time() - last_block_time < 120
-            except ValueError:
-                pass
+        try:
+            last_block_time = datetime.datetime.fromisoformat(normalize_last_block_time).timestamp()
+            is_ready = time.time() - last_block_time < 120
+        except ValueError:
+            is_ready = False
 
         return ClientInfo(
             name="blockbook",


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
https://onekeygroup.slack.com/archives/C02207B6FNC/p1627390593198900?thread_ts=1627373315.177900&cid=C02207B6FNC

blockbook 只要未同步完就会把 inSync 设置为 False，不建议使用

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
…

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
…

## Any other comments?
…
