### PR TITLE
OK-331 wallet: only return time string for confirmed transaction

### DIFF
--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -1128,10 +1128,16 @@ class Abstract_Wallet(AddressSynchronizer, ABC):
                 status = 2  # not SPV verified
         else:
             status = 3 + min(conf, 6)
-        time_str = format_time(timestamp) if timestamp else _("unknown")
-        status_str = TX_STATUS[status] if status < 4 else time_str
-        if extra:
-            status_str += ' [%s]' % (', '.join(extra))
+
+        if status < 4 or timestamp is None:
+            status_str = ""
+            status_to_log = TX_STATUS[status] if status < 4 else "unknown"
+            if extra:
+                status_to_log += ' [%s]' % (', '.join(extra))
+            self.logger.info(f"Dropping not timeinfo status {status_to_log}.")
+        else:
+            status_str = format_time(timestamp)
+
         return status, status_str
 
     def relayfee(self):


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
如果一个transaction没能拿到时间信息（未确认之类的情况），就返回空的`status_str`。原因是我们将这个`status_str`认为是时间信息直接展示了，原来electrum不是这么考虑，所以抛弃掉其它额外的其它情况。

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
[OK-331]

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
No

## Any other comments?
No

[OK-331]: https://onekeyhq.atlassian.net/browse/OK-331