### PR TITLE
OK-2875: get transaction from transaction manager

### DIFF
--- a/electrum_gui/common/transaction/daos.py
+++ b/electrum_gui/common/transaction/daos.py
@@ -215,11 +215,13 @@ def query_actions_by_status(
     status: TxActionStatus,
     chain_code: str = None,
     address: str = None,
+    txid: str = None,
 ) -> List[TxAction]:
     expressions = [TxAction.status == status]
 
     chain_code is None or expressions.append(TxAction.chain_code == chain_code)
     address is None or expressions.append(TxAction.from_address == address or TxAction.to_address == address)
+    txid is None or expressions.append(TxAction.txid == txid)
 
     models = TxAction.select().where(*expressions)
     return list(models)
@@ -234,3 +236,7 @@ def delete_actions_by_addresses(chain_code: str, addresses: List[str]) -> int:
         )
         .execute()
     )
+
+
+def has_actions_by_txid(chain_code: str, txid: str) -> bool:
+    return TxAction.select().where(TxAction.chain_code == chain_code, TxAction.txid == txid).count() > 0

--- a/electrum_gui/common/transaction/manager.py
+++ b/electrum_gui/common/transaction/manager.py
@@ -59,8 +59,25 @@ def update_action_status(
     daos.update_actions_status(chain_code, txid, status)
 
 
-def update_pending_actions(chain_code: Optional[str] = None, address: Optional[str] = None):
-    pending_actions = daos.query_actions_by_status(TxActionStatus.PENDING, chain_code=chain_code, address=address)
+def has_actions_by_txid(chain_code: str, txid: str) -> bool:
+    return daos.has_actions_by_txid(chain_code, txid)
+
+
+def query_actions_by_txid(chain_code: str, txid: str) -> List[TxAction]:
+    return daos.query_actions_by_txid(chain_code, txid)
+
+
+def update_pending_actions(
+    chain_code: Optional[str] = None,
+    address: Optional[str] = None,
+    txid: Optional[str] = None,
+):
+    pending_actions = daos.query_actions_by_status(
+        TxActionStatus.PENDING,
+        chain_code=chain_code,
+        address=address,
+        txid=txid,
+    )
 
     if not pending_actions:
         return


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
如果交易被 transaction manager 记录过，直接通过 transaction manager 获取

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
https://onekeyhq.atlassian.net/browse/OK-3159

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
…

## Any other comments?
…
