### PR TITLE
OK-3097: btc: return faster fees

### DIFF
--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -1003,7 +1003,7 @@ class AndroidCommands(commands.Commands):
             out_info = [
                 # Assuming all needed data are present
                 self._format_return_data(fee_info_list.get(block), out_size_p2pkh, block)
-                for block in (2, 5, 10)
+                for block in (5, 2, 1)
             ]
         else:
             block = helpers.get_best_block_by_feerate(float(feerate) * 1000, fee_info_list)


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
将BTC的费率提升成5/2/1个区块的费率，对应 [OK-238] 的改动。
排序和其它币种的返回保持一致，从慢到快。


## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
[OK-3097]

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
No

## Any other comments?
No


[OK-238]: https://onekeyhq.atlassian.net/browse/OK-238
[OK-3097]: https://onekeyhq.atlassian.net/browse/OK-3097