### PR TITLE
use chain shortname instead of chain code to name accounts

### DIFF
--- a/electrum_gui/common/coin/data.py
+++ b/electrum_gui/common/coin/data.py
@@ -18,6 +18,7 @@ class ChainInfo(DataClassMixin):
     chain_code: str  # unique chain coin
     fee_coin: str  # which coin is used to provide fee (omni chain uses btc, neo uses neo_gas etc.)
     name: str  # full name of chain, please keep the same with hardware wallet if supports hardware
+    shortname: str  # short name of chain
     chain_model: ChainModel  # model of chain (UTXO, Account etc.)
     curve: secret_data.CurveEnum  # curve type
     chain_affinity: str  # mark chain affinity

--- a/electrum_gui/common/conf/chains.py
+++ b/electrum_gui/common/conf/chains.py
@@ -473,6 +473,7 @@ def get_added_chains(existing_chain_codes: Set[str]) -> List[Dict]:
             "chain_code": chain_code,
             "fee_coin": chain_settings["fee_coin"],
             "name": chain_settings["name"],
+            "shortname": chain_settings["shortname"],
             "chain_model": chain_settings["chain_model"],
             "curve": chain_settings["curve"],
             "chain_affinity": chain_settings["chain_affinity"],


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
小改善，用shortname而非处理过后的chain code来命名账户，原因是很多时候chain code不一定和shortname保持一致，前者不好改动，后者可能变化。典型的例子是`okt`->`OEC`。

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
[OK-3304] 相关

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
No

## Any other comments?
No


[OK-3304]: https://onekeyhq.atlassian.net/browse/OK-3304