### PR TITLE
OK-3397 Clear hw_info before getting xpub for hw derived wallets

### DIFF
--- a/electrum_gui/android/console.py
+++ b/electrum_gui/android/console.py
@@ -3189,6 +3189,7 @@ class AndroidCommands(commands.Commands):
         :coin: btc/eth as string
         :return: xpub as string
         """
+        self.hw_info.clear()
         if is_coin_migrated(coin):
             return self._get_xpub_from_hw(path=path, _type=_type, coin=coin, bip39_derivation=bip39_derivation)
 


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
获取硬件派生钱包之前清空hw_info，否则创建失败会有残留数据

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
[OK-3397]

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
iOS

## Any other comments?
硬件创建这里的流程需要大改，具体见 [OK-3397] 中的讨论

[OK-3397]: https://onekeyhq.atlassian.net/browse/OK-3397
[OK-3397]: https://onekeyhq.atlassian.net/browse/OK-3397