### PR TITLE
OK-3799 eth_wallet: use decimal.Decimal(0) as default main balance

### DIFF
--- a/electrum/eth_wallet.py
+++ b/electrum/eth_wallet.py
@@ -248,7 +248,7 @@ class Abstract_Eth_Wallet(abc.ABC):
         return eth_keys.keys.PublicKey(bytes.fromhex(public_key)).to_checksum_address()
 
     def get_all_balance(self) -> Tuple[decimal.Decimal, Dict]:
-        _cached_main_balance = 0
+        _cached_main_balance = decimal.Decimal(0)
         _cached_erc_balances = {}
 
         if self._total_balance.get("time") is not None:


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
用decimal.Decimal(0)作为main_balance的默认值

## Does this close any currently open issues?  
If it fixes a bug or resolves a feature request, be sure to link to that issue.
[OK-3799]

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
_Put an `x` in the boxes that apply_
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Where has this been tested?
No

## Any other comments?
No


[OK-3799]: https://onekeyhq.atlassian.net/browse/OK-3799